### PR TITLE
feat: Oj Serializers 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /pkg/
 /spec/reports/
 /tmp/
+/benchmark/flamegraphs/
 
 # rspec failure tracking
 .rspec_status

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /spec/reports/
 /tmp/
 /benchmark/flamegraphs/
+/gemfiles/*.lock
 
 # rspec failure tracking
 .rspec_status

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -78,3 +78,4 @@ Style/Alias:
   Enabled: false
 AllCops:
   NewCops: enable
+  SuggestExtensions: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -40,6 +40,21 @@ Layout/AccessModifierIndentation:
 Layout/CaseIndentation:
   EnforcedStyle: 'end'
 
+Layout/EndAlignment:
+  Enabled: false
+
+Layout/IndentationWidth:
+  Enabled: false
+
+Layout/ElseAlignment:
+  Enabled: false
+
+Naming/MethodParameterName:
+  Enabled: false
+
+Style/GuardClause:
+  Enabled: false
+
 # Disabled to allow the outdented comment style
 Layout/CommentIndentation:
   Enabled: false
@@ -59,3 +74,7 @@ Metrics/ClassLength:
 
 Naming/PredicateName:
   Enabled: false
+Style/Alias:
+  Enabled: false
+AllCops:
+  NewCops: enable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## [Oj Serializers 2.0.0 (2023-03-27)](https://github.com/ElMassimo/oj_serializers/pull/9)
+
+### Features ✨
+
+- Improved performance (20% to 40% faster than v1)
+- Added `render_as_hash` to efficiently build a Hash from the serializer
+- `transform_keys :camelize`: a built-in setting to convert keys, in a way that does not affect runtime performance
+- `sort_keys_by :name`: allows to sort the response alphabetically, without affecting runtime performance
+- `render` shortcut, unifying `one` and `many`
+- `attribute` as an easier approach to define serializer attributes
+
+### Breaking Changes
+
+Since returning a `Hash` is more convenient than returning a `Oj::StringWriter`, and performance is comparable, `default_format :hash` is now the default.
+
+The previous APIs will still be available as `one_as_json` and `many_as_json`, as well as `default_format :json` to make the library work like in version 1.
+
 ## Oj Serializers 1.0.2 (2023-03-01) ##
 
 *   [fix: avoid freezing `ALLOWED_INSTANCE_VARIABLES`](https://github.com/ElMassimo/oj_serializers/commit/ade0302)

--- a/Gemfile
+++ b/Gemfile
@@ -24,5 +24,6 @@ group :development, :test do
   gem 'rake', '~> 13.0'
   gem 'rspec-rails', '~> 4.0'
   gem 'simplecov', '< 0.18'
+  gem 'singed'
   gem 'sqlite3'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -11,16 +11,14 @@ group :development do
 end
 
 group :development, :test do
-  gem 'actionpack'
   gem 'active_model_serializers', '~> 0.8'
-  gem 'activerecord'
   gem 'benchmark-ips'
   gem 'benchmark-memory'
   gem 'blueprinter', '~> 0.8'
   gem 'memory_profiler'
   gem 'mongoid'
   gem 'pry-byebug', '~> 3.9'
-  gem 'railties'
+  gem 'rails' unless ENV['NO_RAILS']
   gem 'rake', '~> 13.0'
   gem 'rspec-rails', '~> 4.0'
   gem 'simplecov', '< 0.18'

--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,28 @@
 
 source 'https://rubygems.org'
 
+git_source(:github) { |repo| "https://github.com/#{repo}.git" }
+
 # Specify your gem's dependencies in oj_serializers.gemspec
 gemspec
 
 group :development do
   gem 'rubocop'
+end
+
+group :development, :test do
+  gem 'actionpack'
+  gem 'active_model_serializers', '~> 0.8'
+  gem 'activerecord'
+  gem 'benchmark-ips'
+  gem 'benchmark-memory'
+  gem 'blueprinter', '~> 0.8'
+  gem 'memory_profiler'
+  gem 'mongoid'
+  gem 'pry-byebug', '~> 3.9'
+  gem 'railties'
+  gem 'rake', '~> 13.0'
+  gem 'rspec-rails', '~> 4.0'
+  gem 'simplecov', '< 0.18'
+  gem 'sqlite3'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -12,11 +12,13 @@ end
 
 group :development, :test do
   gem 'active_model_serializers', '~> 0.8'
+  gem 'alba'
   gem 'benchmark-ips'
   gem 'benchmark-memory'
   gem 'blueprinter', '~> 0.8'
   gem 'memory_profiler'
   gem 'mongoid'
+  gem 'panko_serializer'
   gem 'pry-byebug', '~> 3.9'
   gem 'rails' unless ENV['NO_RAILS']
   gem 'rake', '~> 13.0'

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ source 'https://rubygems.org'
 
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-# Specify your gem's dependencies in oj_serializers.gemspec
 gemspec
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,7 +36,7 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2, >= 2.2.2)
-    ast (2.4.1)
+    ast (2.4.2)
     benchmark-ips (2.8.3)
     benchmark-memory (0.1.2)
       memory_profiler (~> 0.9)
@@ -72,8 +72,8 @@ GEM
     nokogiri (1.14.2-x86_64-linux)
       racc (~> 1.4)
     oj (3.14.2)
-    parallel (1.19.2)
-    parser (2.7.1.4)
+    parallel (1.22.1)
+    parser (3.2.1.1)
       ast (~> 2.4.1)
     pry (0.13.1)
       coderay (~> 1.1)
@@ -96,10 +96,10 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.20.3, < 2.0)
-    rainbow (3.0.0)
+    rainbow (3.1.1)
     rake (13.0.6)
-    regexp_parser (1.7.1)
-    rexml (3.2.4)
+    regexp_parser (2.7.0)
+    rexml (3.2.5)
     rspec-core (3.9.3)
       rspec-support (~> 3.9.3)
     rspec-expectations (3.9.3)
@@ -117,18 +117,19 @@ GEM
       rspec-mocks (~> 3.9)
       rspec-support (~> 3.9)
     rspec-support (3.9.4)
-    rubocop (0.86.0)
+    rubocop (1.48.1)
+      json (~> 2.3)
       parallel (~> 1.10)
-      parser (>= 2.7.0.1)
+      parser (>= 3.2.0.0)
       rainbow (>= 2.2.2, < 4.0)
-      regexp_parser (>= 1.7)
-      rexml
-      rubocop-ast (>= 0.0.3, < 1.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.26.0, < 2.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (>= 1.4.0, < 2.0)
-    rubocop-ast (0.1.0)
-      parser (>= 2.7.0.1)
-    ruby-progressbar (1.10.1)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.27.0)
+      parser (>= 3.2.1.0)
+    ruby-progressbar (1.13.0)
     simplecov (0.17.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -139,7 +140,7 @@ GEM
     thread_safe (0.3.6)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
-    unicode-display_width (1.7.0)
+    unicode-display_width (2.4.2)
     zeitwerk (2.4.1)
 
 PLATFORMS
@@ -147,7 +148,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  actionpack (>= 4.0)
+  actionpack
   active_model_serializers (~> 0.8)
   activerecord
   benchmark-ips
@@ -157,7 +158,7 @@ DEPENDENCIES
   mongoid
   oj_serializers!
   pry-byebug (~> 3.9)
-  railties (>= 4.0)
+  railties
   rake (~> 13.0)
   rspec-rails (~> 4.0)
   rubocop

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,23 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    actioncable (6.0.3.4)
+      actionpack (= 6.0.3.4)
+      nio4r (~> 2.0)
+      websocket-driver (>= 0.6.1)
+    actionmailbox (6.0.3.4)
+      actionpack (= 6.0.3.4)
+      activejob (= 6.0.3.4)
+      activerecord (= 6.0.3.4)
+      activestorage (= 6.0.3.4)
+      activesupport (= 6.0.3.4)
+      mail (>= 2.7.1)
+    actionmailer (6.0.3.4)
+      actionpack (= 6.0.3.4)
+      actionview (= 6.0.3.4)
+      activejob (= 6.0.3.4)
+      mail (~> 2.5, >= 2.5.4)
+      rails-dom-testing (~> 2.0)
     actionpack (6.0.3.4)
       actionview (= 6.0.3.4)
       activesupport (= 6.0.3.4)
@@ -14,6 +31,12 @@ GEM
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.2.0)
+    actiontext (6.0.3.4)
+      actionpack (= 6.0.3.4)
+      activerecord (= 6.0.3.4)
+      activestorage (= 6.0.3.4)
+      activesupport (= 6.0.3.4)
+      nokogiri (>= 1.8.5)
     actionview (6.0.3.4)
       activesupport (= 6.0.3.4)
       builder (~> 3.1)
@@ -25,11 +48,19 @@ GEM
       activemodel (>= 4.1, < 6.1)
       case_transform (>= 0.2)
       jsonapi-renderer (>= 0.1.1.beta1, < 0.3)
+    activejob (6.0.3.4)
+      activesupport (= 6.0.3.4)
+      globalid (>= 0.3.6)
     activemodel (6.0.3.4)
       activesupport (= 6.0.3.4)
     activerecord (6.0.3.4)
       activemodel (= 6.0.3.4)
       activesupport (= 6.0.3.4)
+    activestorage (6.0.3.4)
+      actionpack (= 6.0.3.4)
+      activejob (= 6.0.3.4)
+      activerecord (= 6.0.3.4)
+      marcel (~> 0.3.1)
     activesupport (6.0.3.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
@@ -50,9 +81,12 @@ GEM
     colorize (0.8.1)
     concurrent-ruby (1.1.7)
     crass (1.0.6)
+    date (3.3.3)
     diff-lcs (1.4.4)
     docile (1.3.2)
     erubi (1.9.0)
+    globalid (1.1.0)
+      activesupport (>= 5.0)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     json (2.3.1)
@@ -60,14 +94,35 @@ GEM
     loofah (2.7.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
+    mail (2.8.1)
+      mini_mime (>= 0.1.1)
+      net-imap
+      net-pop
+      net-smtp
+    marcel (0.3.3)
+      mimemagic (~> 0.3.2)
     memory_profiler (0.9.14)
     method_source (1.0.0)
+    mimemagic (0.3.10)
+      nokogiri (~> 1)
+      rake
+    mini_mime (1.1.2)
     minitest (5.18.0)
     mongo (2.13.1)
       bson (>= 4.8.2, < 5.0.0)
     mongoid (7.1.4)
       activemodel (>= 5.1, < 6.1)
       mongo (>= 2.7.0, < 3.0.0)
+    net-imap (0.3.4)
+      date
+      net-protocol
+    net-pop (0.1.2)
+      net-protocol
+    net-protocol (0.2.1)
+      timeout
+    net-smtp (0.3.3)
+      net-protocol
+    nio4r (2.5.8)
     nokogiri (1.14.2-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.14.2-x86_64-linux)
@@ -86,6 +141,21 @@ GEM
     rack (2.2.3)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
+    rails (6.0.3.4)
+      actioncable (= 6.0.3.4)
+      actionmailbox (= 6.0.3.4)
+      actionmailer (= 6.0.3.4)
+      actionpack (= 6.0.3.4)
+      actiontext (= 6.0.3.4)
+      actionview (= 6.0.3.4)
+      activejob (= 6.0.3.4)
+      activemodel (= 6.0.3.4)
+      activerecord (= 6.0.3.4)
+      activestorage (= 6.0.3.4)
+      activesupport (= 6.0.3.4)
+      bundler (>= 1.3.0)
+      railties (= 6.0.3.4)
+      sprockets-rails (>= 2.0.0)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
@@ -139,13 +209,24 @@ GEM
     singed (0.1.1)
       colorize
       stackprof
+    sprockets (4.1.1)
+      concurrent-ruby (~> 1.0)
+      rack (> 1, < 3)
+    sprockets-rails (3.4.2)
+      actionpack (>= 5.2)
+      activesupport (>= 5.2)
+      sprockets (>= 3.0.0)
     sqlite3 (1.4.2)
     stackprof (0.2.24)
     thor (1.0.1)
     thread_safe (0.3.6)
+    timeout (0.3.2)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     unicode-display_width (2.4.2)
+    websocket-driver (0.7.5)
+      websocket-extensions (>= 0.1.0)
+    websocket-extensions (0.1.5)
     zeitwerk (2.4.1)
 
 PLATFORMS
@@ -153,9 +234,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  actionpack
   active_model_serializers (~> 0.8)
-  activerecord
   benchmark-ips
   benchmark-memory
   blueprinter (~> 0.8)
@@ -163,7 +242,7 @@ DEPENDENCIES
   mongoid
   oj_serializers!
   pry-byebug (~> 3.9)
-  railties
+  rails
   rake (~> 13.0)
   rspec-rails (~> 4.0)
   rubocop

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,8 @@ GEM
       zeitwerk (~> 2.2, >= 2.2.2)
     ast (2.4.1)
     benchmark-ips (2.8.3)
+    benchmark-memory (0.1.2)
+      memory_profiler (~> 0.9)
     blueprinter (0.25.3)
     bson (4.11.1)
     builder (3.2.4)
@@ -149,6 +151,7 @@ DEPENDENCIES
   active_model_serializers (~> 0.8)
   activerecord
   benchmark-ips
+  benchmark-memory
   blueprinter (~> 0.8)
   memory_profiler
   mongoid

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,7 @@ GEM
     case_transform (0.2)
       activesupport
     coderay (1.1.3)
+    colorize (0.8.1)
     concurrent-ruby (1.1.7)
     crass (1.0.6)
     diff-lcs (1.4.4)
@@ -135,7 +136,11 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
+    singed (0.1.1)
+      colorize
+      stackprof
     sqlite3 (1.4.2)
+    stackprof (0.2.24)
     thor (1.0.1)
     thread_safe (0.3.6)
     tzinfo (1.2.7)
@@ -163,6 +168,7 @@ DEPENDENCIES
   rspec-rails (~> 4.0)
   rubocop
   simplecov (< 0.18)
+  singed
   sqlite3
 
 BUNDLED WITH

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,7 @@ GEM
       zeitwerk (~> 2.2, >= 2.2.2)
     ast (2.4.1)
     benchmark-ips (2.8.3)
+    blueprinter (0.25.3)
     bson (4.11.1)
     builder (3.2.4)
     byebug (11.1.3)
@@ -148,6 +149,7 @@ DEPENDENCIES
   active_model_serializers (~> 0.8)
   activerecord
   benchmark-ips
+  blueprinter (~> 0.8)
   memory_profiler
   mongoid
   oj_serializers!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    oj_serializers (2.0.0.pre.beta.1)
+    oj_serializers (2.0.0)
       oj (>= 3.14.0)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    oj_serializers (1.0.2)
+    oj_serializers (2.0.0.pre.beta.1)
       oj (>= 3.14.0)
 
 GEM

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,6 +67,7 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2, >= 2.2.2)
+    alba (2.2.0)
     ast (2.4.2)
     benchmark-ips (2.8.3)
     benchmark-memory (0.1.2)
@@ -128,6 +129,9 @@ GEM
     nokogiri (1.14.2-x86_64-linux)
       racc (~> 1.4)
     oj (3.14.2)
+    panko_serializer (0.7.9)
+      activesupport
+      oj (> 3.11.0, < 4.0.0)
     parallel (1.22.1)
     parser (3.2.1.1)
       ast (~> 2.4.1)
@@ -235,12 +239,14 @@ PLATFORMS
 
 DEPENDENCIES
   active_model_serializers (~> 0.8)
+  alba
   benchmark-ips
   benchmark-memory
   blueprinter (~> 0.8)
   memory_profiler
   mongoid
   oj_serializers!
+  panko_serializer
   pry-byebug (~> 3.9)
   rails
   rake (~> 13.0)

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -96,7 +96,7 @@ class AlbumSerializer < Oj::Serializer
 
   has_many :songs, serializer: SongSerializer
 
-  serialize if: -> { album.released? }
+  attr if: -> { album.released? }
   def release
     album.release_date.strftime('%B %d, %Y')
   end

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -96,16 +96,16 @@ class AlbumSerializer < Oj::Serializer
 
   has_many :songs, serializer: SongSerializer
 
-  attribute \
+  serialize if: -> { album.released? }
   def release
     album.release_date.strftime('%B %d, %Y')
-  end, if: -> { album.released? }
+  end
 end
 ```
 
-The shorthand syntax for serializer attributes might not be very palatable at
-first, but having the entire definition in one place makes it a lot easier to
-follow, specially in large serializers.
+The shorthand syntax for serializer attributes might seem odd at first, but it
+makes it a lot easier to differentiate helper methods from attributes,
+especially in large serializers.
 
 ## Migrate gradually, one at a time
 

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -2,15 +2,16 @@
 
 [request_store]: https://github.com/steveklabnik/request_store
 [request_store_rails]: https://github.com/ElMassimo/request_store_rails
-[readme]: https://github.com/ElMassimo/oj_serializers/blob/master/README.md
+[readme]: https://github.com/ElMassimo/oj_serializers/blob/main/README.md
+[attributes dsl]: https://github.com/ElMassimo/oj_serializers/blob/main/README.md#attributes-dsl-
 
 [oj]: https://github.com/ohler55/oj
 [ams]: https://github.com/rails-api/active_model_serializers
 [jsonapi]: https://github.com/jsonapi-serializer/jsonapi-serializer
 [panko]: https://github.com/panko-serializer/panko_serializer
 [benchmarks]: https://github.com/ElMassimo/oj_serializers/tree/master/benchmarks
-[raw_benchmarks]: https://github.com/ElMassimo/oj_serializers/blob/master/benchmarks/document_benchmark.rb
-[migration guide]: https://github.com/ElMassimo/oj_serializers/blob/master/MIGRATION_GUIDE.md
+[raw_benchmarks]: https://github.com/ElMassimo/oj_serializers/blob/main/benchmarks/document_benchmark.rb
+[migration guide]: https://github.com/ElMassimo/oj_serializers/blob/main/MIGRATION_GUIDE.md
 [raw_json]: https://github.com/ohler55/oj/issues/542
 [trailing_commas]: https://maximomussini.com/posts/trailing-commas/
 
@@ -44,9 +45,19 @@ render json: {
 
 ### Attributes
 
-Have in mind that unlike in Active Model Serializers, `attributes` in `Oj::Serializer` will _not_ take into account methods defined in the serializer.
+If you read the [Attributes DSL] section, you might have noticed that you need
+to _explicitly_ tell when a method in the serializer should be used by
+specifying it with `attribute`.
 
-Specially in the beginning, you can replace `attributes` with `ams_attributes` to preserve the same behavior.
+This makes the serializers more predictable and more maintainable, but it can
+make it challenging to migrate from `active_model_serializers`.
+
+Specially in the beginning, you can replace `attributes` with `ams_attributes`
+to preserve the same behavior.
+
+`ams_attributes` works like `attributes` in `active_model_serializers`: by
+calling a method in the serializer if defined, or calling
+`read_attribute_for_serialization` in the model.
 
 ```ruby
 class AlbumSerializer < ActiveModel::Serializer
@@ -96,7 +107,7 @@ class AlbumSerializer < Oj::Serializer
 
   has_many :songs, serializer: SongSerializer
 
-  attr if: -> { album.released? }
+  attribute if: -> { album.released? }
   def release
     album.release_date.strftime('%B %d, %Y')
   end

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ JSON serializers for Ruby, built on top of the powerful [`oj`][oj] library.
 [design]: https://github.com/ElMassimo/oj_serializers#design-
 [raw_json]: https://github.com/ohler55/oj/issues/542
 [trailing_commas]: https://maximomussini.com/posts/trailing-commas/
+[render dsl]: https://github.com/ElMassimo/oj_serializers#render-dsl-
 
 ## Why? 🤔
 
@@ -38,7 +39,7 @@ Learn more about [how this library achieves its performance][design].
 
 - Declaration syntax similar to Active Model Serializers
 - Reduced memory allocation and [improved performance][benchmarks]
-- Support for `has_one` and `has_many`, compose with `flat_one`
+- Support for `has_one` and `has_many`; compose with `flat_one`
 - Useful development checks to avoid typos and mistakes
 - Integrates nicely with Rails controllers
 - Caching
@@ -396,6 +397,88 @@ private
 end
 ```
 
+### Render to Hash
+
+In cases where you need objects instead of a JSON string, you can use `render_as_hash`:
+
+```ruby
+album = Album.find(params[:id])
+AlbumSerializer.render_as_hash(album)
+# {name: "Abraxas", genres: ["Pyschodelic Rock", "Blues Rock", ...
+
+albums = Album.all
+PersonSerializer.render_as_hash(albums)
+# [{name: "Abraxas", genres: ["Pyschodelic Rock", "Blues Rock", ...
+```
+
+<details>
+  <summary>Example Output</summary>
+
+```ruby
+{
+  name: "Abraxas",
+  genres: [
+    "Pyschodelic Rock",
+    "Blues Rock",
+    "Jazz Fusion",
+    "Latin Rock",
+  ],
+  release: "September 23, 1970",
+  songs: [
+    {
+      track: 1,
+      name: "Sing Winds, Crying Beasts",
+      composers: ["Michael Carabello"],
+    },
+    {
+      track: 2,
+      name: "Black Magic Woman / Gypsy Queen",
+      composers: ["Peter Green", "Gábor Szabó"],
+    },
+    {
+      track: 3,
+      name: "Oye como va",
+      composers: ["Tito Puente"],
+    },
+    {
+      track: 4,
+      name: "Incident at Neshabur",
+      composers: ["Alberto Gianquinto", "Carlos Santana"],
+    },
+    {
+      track: 5,
+      name: "Se acabó",
+      composers: ["José Areas"],
+    },
+    {
+      track: 6,
+      name: "Mother's Daughter",
+      composers: ["Gregg Rolie"],
+    },
+    {
+      track: 7,
+      name: "Samba pa ti",
+      composers: ["Santana"],
+    },
+    {
+      track: 8,
+      name: "Hope You're Feeling Better",
+      composers: ["Rolie"],
+    },
+    {
+      track: 9,
+      name: "El Nicoya",
+      composers: ["Areas"],
+    },
+  ],
+}
+```
+</details>
+
+Have in mind that building a hash is typically less performant than writing to a
+string directly, as more objects are allocated, so prefer using the [Render DSL]
+whenever possible.
+
 ### Caching 📦
 
 Use `cached` to leverage key-based caching, which calls `cache_key` in the object. You can also provide a lambda to `cached_with_key` to define a custom key:
@@ -415,7 +498,7 @@ Usually serialization happens so fast that __turning caching on can be slower__.
 ## Design 📐
 
 Unlike `ActiveModel::Serializer`, which builds a Hash that then gets encoded to
-JSON, this implementation uses `Oj::StringWriter` to write JSON directly,
+JSON, this implementation can use `Oj::StringWriter` to write JSON directly,
 greatly reducing the overhead of allocating and garbage collecting the hashes.
 
 It also allocates a single instance per serializer class, which makes it easy

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ JSON serializers for Ruby, built on top of the powerful [`oj`][oj] library.
 [ams]: https://github.com/rails-api/active_model_serializers
 [jsonapi]: https://github.com/jsonapi-serializer/jsonapi-serializer
 [panko]: https://github.com/panko-serializer/panko_serializer
+[blueprinter]: https://github.com/procore/blueprinter
 [benchmarks]: https://github.com/ElMassimo/oj_serializers/tree/master/benchmarks
 [raw_benchmarks]: https://github.com/ElMassimo/oj_serializers/blob/master/benchmarks/document_benchmark.rb
 [sugar]: https://github.com/ElMassimo/oj_serializers/blob/master/lib/oj_serializers/sugar.rb#L14
@@ -25,11 +26,12 @@ JSON serializers for Ruby, built on top of the powerful [`oj`][oj] library.
 [raw_json]: https://github.com/ohler55/oj/issues/542
 [trailing_commas]: https://maximomussini.com/posts/trailing-commas/
 [render dsl]: https://github.com/ElMassimo/oj_serializers#render-dsl-
+[sorbet]: https://sorbet.org/
 
 ## Why? 🤔
 
-[`ActiveModel::Serializer`][ams] has a nice DSL, but it allocates many objects leading
-to memory bloat, time spent on GC, and lower performance.
+[`ActiveModel::Serializer`][ams] has a nice DSL, but it allocates many objects
+leading to memory bloat, time spent on GC, and lower performance.
 
 `Oj::Serializer` provides a similar API, with [better performance][benchmarks].
 
@@ -39,10 +41,9 @@ Learn more about [how this library achieves its performance][design].
 
 - Declaration syntax similar to Active Model Serializers
 - Reduced memory allocation and [improved performance][benchmarks]
-- Support for `has_one` and `has_many`; compose with `flat_one`
+- Support for `has_one` and `has_many`, compose with `flat_one`
 - Useful development checks to avoid typos and mistakes
 - Integrates nicely with Rails controllers
-- Caching
 
 ## Installation 💿
 
@@ -59,13 +60,13 @@ And then run:
 ## Usage 🚀
 
 You can define a serializer by subclassing `Oj::Serializer`, and specify which
-attributes should be serialized to JSON.
+attributes should be serialized.
 
 ```ruby
 class AlbumSerializer < Oj::Serializer
   attributes :name, :genres
 
-  attribute \
+  serialize
   def release
     album.release_date.strftime('%B %d, %Y')
   end
@@ -73,6 +74,341 @@ class AlbumSerializer < Oj::Serializer
   has_many :songs, serializer: SongSerializer
 end
 ```
+
+<details>
+  <summary>Example Output</summary>
+
+```ruby
+{
+  name: "Abraxas",
+  genres: [
+    "Pyschodelic Rock",
+    "Blues Rock",
+    "Jazz Fusion",
+    "Latin Rock",
+  ],
+  release: "September 23, 1970",
+  songs: [
+    {
+      track: 1,
+      name: "Sing Winds, Crying Beasts",
+      composers: ["Michael Carabello"],
+    },
+    {
+      track: 2,
+      name: "Black Magic Woman / Gypsy Queen",
+      composers: ["Peter Green", "Gábor Szabó"],
+    },
+    {
+      track: 3,
+      name: "Oye como va",
+      composers: ["Tito Puente"],
+    },
+    {
+      track: 4,
+      name: "Incident at Neshabur",
+      composers: ["Alberto Gianquinto", "Carlos Santana"],
+    },
+    {
+      track: 5,
+      name: "Se acabó",
+      composers: ["José Areas"],
+    },
+    {
+      track: 6,
+      name: "Mother's Daughter",
+      composers: ["Gregg Rolie"],
+    },
+    {
+      track: 7,
+      name: "Samba pa ti",
+      composers: ["Santana"],
+    },
+    {
+      track: 8,
+      name: "Hope You're Feeling Better",
+      composers: ["Rolie"],
+    },
+    {
+      track: 9,
+      name: "El Nicoya",
+      composers: ["Areas"],
+    },
+  ],
+}
+```
+</details>
+
+<br/>
+
+To use the serializer, the recommended approach is:
+
+```ruby
+class AlbumsController < ApplicationController
+  def show
+    album = Album.find(params[:id])
+    render json: AlbumSerializer.one(album)
+  end
+
+  def index
+    albums = Album.all
+    render json: { albums: AlbumSerializer.many(albums) }
+  end
+end
+```
+
+If you are using Rails you can also use something closer to Active Model Serializers by adding [`sugar`][sugar]:
+
+```ruby
+require 'oj_serializers/sugar'
+
+class AlbumsController < ApplicationController
+  def show
+    album = Album.find(params[:id])
+    render json: album, serializer: AlbumSerializer
+  end
+
+  def index
+    albums = Album.all
+    render json: albums, each_serializer: AlbumSerializer, root: :albums
+  end
+end
+```
+
+It's recommended to create your own `BaseSerializer` class in order to easily
+add custom extensions, specially when migrating from `active_model_serializers`.
+
+## Render DSL 🛠
+
+In order to efficiently reuse the instances, serializers can't be instantiated directly. Use `one` and `many` to serialize objects or enumerables:
+
+```ruby
+render json: {
+  favorite_album: AlbumSerializer.one(album),
+  purchased_albums: AlbumSerializer.many(albums),
+}
+```
+
+You can use these serializers inside arrays, hashes, or even inside `ActiveModel::Serializer` by using a method in the serializer.
+
+## Attributes DSL 🛠
+
+Attributes methods can be used to define which model attributes should be serialized
+to JSON. Each method provides a different strategy to obtain the values to serialize.
+
+The internal design is simple and extensible, so creating new strategies requires very little code.
+Please open an issue if you need help 😃
+
+### `attributes`
+
+Obtains the attribute value by calling a method in the object being serialized.
+
+```ruby
+class PlayerSerializer < Oj::Serializer
+  attributes :full_name
+end
+```
+
+Have in mind that unlike Active Model Serializers, it will _not_ take into
+account methods defined in the serializer. Being explicit about where the
+attribute is coming from makes the serializers easier to understand and more
+maintainable.
+
+### `serializer_attributes`
+
+Obtains the attribute value by calling a method defined in the serializer.
+
+Simply call `serialize` right before defining the method, and it will be serialized:
+
+```ruby
+class PlayerSerializer < Oj::Serializer
+  serialize
+  def full_name
+    "#{player.first_name} #{player.last_name}"
+  end
+end
+```
+
+> This inline syntax was inspired by how types are defined in [`sorbet`][sorbet].
+
+Instance methods can access the object by the serializer name without the
+`Serializer` suffix, `player` in the example above, or directly as `@object`.
+
+You can customize this by using [`object_as`](#using-a-different-alias-for-the-internal-object).
+
+### `ams_attributes` 🐌
+
+Works like `attributes` in Active Model Serializers, by calling a method in the serializer if defined, or calling `read_attribute_for_serialization` in the model.
+
+```ruby
+class AlbumSerializer < Oj::Serializer
+  ams_attributes :name, :release
+
+  def release
+    album.release_date.strftime('%B %d, %Y')
+  end
+end
+```
+
+Should only be used when migrating from Active Model Serializers, as it's slower and can create confusion.
+
+Instead, use `attributes` for model methods, and the inline `attribute` for serializer attributes. Being explicit makes serializers easier to understand, and to maintain.
+
+Please refer to the [migration guide] for more information.
+
+### `hash_attributes` 🚀
+
+Very convenient when serializing Hash-like structures, this strategy uses the `[]` operator.
+
+```ruby
+class PersonSerializer < Oj::Serializer
+  hash_attributes 'first_name', :last_name
+end
+
+PersonSerializer.one('first_name' => 'Mary', :middle_name => 'Jane', :last_name => 'Watson')
+# {"first_name":"Mary","last_name":"Watson"}
+```
+
+### `mongo_attributes` 🚀
+
+Reads data directly from `attributes` in a [Mongoid] document.
+
+By skipping type casting, coercion, and defaults, it [achieves the best performance][raw_benchmarks].
+
+Although there are some downsides, depending on how consistent your schema is,
+and which kind of consumer the API has, it can be really powerful.
+
+```ruby
+class AlbumSerializer < Oj::Serializer
+  mongo_attributes :id, :name
+end
+```
+
+## Associations DSL 🛠
+
+Use `has_one` to serialize individual objects, and `has_many` to serialize a collection.
+
+The value for the association is obtained from a serializer method if defined,
+or by calling the method in the object being serialized.
+
+You must specificy which serializer to use with the `serializer` option.
+
+```ruby
+class SongSerializer < Oj::Serializer
+  has_one :album, serializer: AlbumSerializer
+  has_many :composers, serializer: ComposerSerializer
+
+  # You can also compose serializers using `flat_one`.
+  flat_one :song, serializer: SongMetadataSerializer
+end
+```
+
+The associations DSL is essentially a shortcut for defining attributes manually:
+
+```ruby
+class SongSerializer < SongMetadataSerializer
+  serialize
+  def album
+    AlbumSerializer.one(song.album)
+  end
+
+  serialize
+  def composers
+    ComposerSerializer.many(song.composers)
+  end
+end
+```
+
+## Other DSL 🛠
+
+### Using a different alias for the internal object
+
+You can use `object_as` to create an alias for the serialized object to access it from instance methods:
+
+```ruby
+class DiscographySerializer < Oj::Serializer
+  object_as :artist
+
+  # Now we can use `artist` instead of `object` or `discography`.
+  serialize
+  def latest_albums
+    artist.albums.desc(:year)
+  end
+end
+```
+
+### Aliasing or renaming attributes
+
+You can pass `as` when defining an attribute or association to serialize it
+using a different key:
+
+```ruby
+class SongSerializer < Oj::Serializer
+  has_one :album, as: :latest_album, serializer: AlbumSerializer
+
+  attribute :title, as: :name
+end
+```
+
+### Rendering an attribute conditionally
+
+All the attributes and association methods can take an `if` option to render conditionally.
+
+```ruby
+class AlbumSerializer < Oj::Serializer
+  mongo_attributes :release_date, if: -> { album.released? }
+
+  has_many :songs, serializer: SongSerializer, if: -> { album.songs.any? }
+
+  # You can achieve the same by manually defining a method:
+  def include_songs?
+    album.songs.any?
+  end
+end
+```
+
+### Memoization & Local State
+
+Serializers are designed to be stateless so that an instanced can be reused, but sometimes it's convenient to store intermediate calculations.
+
+Use `memo` for memoization and storing temporary information.
+
+```ruby
+class DownloadSerializer < Oj::Serializer
+  attributes :filename, :size
+
+  serialize
+  def progress
+    "#{ last_event&.progress || 0 }%"
+  end
+
+private
+
+  def last_event
+    memo.fetch(:last_event) {
+      download.events.desc(:created_at).first
+    }
+  end
+end
+```
+
+### Writing directly to JSON
+
+In some corner cases it might be faster to serialize using a `Oj::StringWriter`.
+
+You can toggle this mode at a serializer level by using `default_format :json`,
+or configure it globally from your base serializer.
+
+```ruby
+class BaseSerializer < Oj::Serializer
+  default_format :json # :hash is the default
+end
+```
+
+This will change the default shortcuts (`render`, `one`, `one_if`, and `many`),
+so that the serializer writes directly to JSON instead of returning a Hash.
+
+Follow [this discussion][raw_json] to find out more about [the `raw_json` extensions][raw_json] that made this high level of interoperability possible.
 
 <details>
   <summary>Example Output</summary>
@@ -158,343 +494,6 @@ end
 ```
 </details>
 
-<br/>
-
-To use the serializer, the recommended approach is:
-
-```ruby
-class AlbumsController < ApplicationController
-  def show
-    album = Album.find(params[:id])
-    render json: AlbumSerializer.one(album)
-  end
-
-  def index
-    albums = Album.all
-    render json: { albums: AlbumSerializer.many(albums) }
-  end
-end
-```
-
-If you are using Rails you can also use something closer to Active Model Serializers by adding [`sugar`][sugar]:
-
-```ruby
-require 'oj_serializers/sugar'
-
-class AlbumsController < ApplicationController
-  def show
-    album = Album.find(params[:id])
-    render json: album, serializer: AlbumSerializer
-  end
-
-  def index
-    albums = Album.all
-    render json: albums, each_serializer: AlbumSerializer, root: :albums
-  end
-end
-```
-
-It's recommended to create your own `BaseSerializer` class in order to easily
-add custom extensions, specially when migrating from `active_model_serializers`.
-
-## Render DSL 🛠
-
-In order to efficiently reuse the instances, serializers can't be instantiated directly. Use `one` and `many` to serialize objects or enumerables:
-
-```ruby
-render json: {
-  favorite_album: AlbumSerializer.one(album),
-  purchased_albums: AlbumSerializer.many(albums),
-}
-```
-
-You can use these serializers inside arrays, hashes, or even inside `ActiveModel::Serializer` by using a method in the serializer.
-
-Follow [this discussion][raw_json] to find out more about [the `raw_json` extensions][raw_json] that made this high level of interoperability possible.
-
-## Attributes DSL 🛠
-
-Attributes methods can be used to define which model attributes should be serialized
-to JSON. Each method provides a different strategy to obtain the values to serialize.
-
-The internal design is simple and extensible, so creating new strategies requires very little code.
-Please open an issue if you need help 😃
-
-### `attributes`
-
-Obtains the attribute value by calling a method in the object being serialized.
-
-```ruby
-class PlayerSerializer < Oj::Serializer
-  attributes :full_name
-end
-```
-
-Have in mind that unlike Active Model Serializers, it will _not_ take into
-account methods defined in the serializer. Being explicit about where the
-attribute is coming from makes the serializers easier to understand and more
-maintainable.
-
-### `serializer_attributes`
-
-Obtains the attribute value by calling a method defined in the serializer.
-
-
-You may call [`serializer_attributes`](https://github.com/ElMassimo/oj_serializers/blob/master/spec/support/serializers/song_serializer.rb#L13-L15) or use the `attribute` inline syntax:
-
-```ruby
-class PlayerSerializer < Oj::Serializer
-  attribute \
-  def full_name
-    "#{player.first_name} #{player.last_name}"
-  end
-end
-```
-
-Instance methods can access the object by the serializer name without the
-`Serializer` suffix, `player` in the example above, or directly as `@object`.
-
-You can customize this by using [`object_as`](https://github.com/ElMassimo/oj_serializers#using-a-different-alias-for-the-internal-object).
-
-### `ams_attributes` 🐌
-
-Works like `attributes` in Active Model Serializers, by calling a method in the serializer if defined, or calling `read_attribute_for_serialization` in the model.
-
-```ruby
-class AlbumSerializer < Oj::Serializer
-  ams_attributes :name, :release
-
-  def release
-    album.release_date.strftime('%B %d, %Y')
-  end
-end
-```
-
-Should only be used when migrating from Active Model Serializers, as it's slower and can create confusion.
-
-Instead, use `attributes` for model methods, and the inline `attribute` for serializer attributes. Being explicit makes serializers easier to understand, and to maintain.
-
-Please refer to the [migration guide] for more information.
-
-### `hash_attributes` 🚀
-
-Very convenient when serializing Hash-like structures, this strategy uses the `[]` operator.
-
-```ruby
-class PersonSerializer < Oj::Serializer
-  hash_attributes 'first_name', :last_name
-end
-
-PersonSerializer.one('first_name' => 'Mary', :middle_name => 'Jane', :last_name => 'Watson')
-# {"first_name":"Mary","last_name":"Watson"}
-```
-
-### `mongo_attributes` 🚀
-
-Reads data directly from `attributes` in a [Mongoid] document.
-
-By skipping type casting, coercion, and defaults, it [achieves the best performance][raw_benchmarks].
-
-Although there are some downsides, depending on how consistent your schema is,
-and which kind of consumer the API has, it can be really powerful.
-
-```ruby
-class AlbumSerializer < Oj::Serializer
-  mongo_attributes :id, :name
-end
-```
-
-## Associations DSL 🛠
-
-Use `has_one` to serialize individual objects, and `has_many` to serialize a collection.
-
-The value for the association is obtained from a serializer method if defined, or by calling the method in the object being serialized.
-
-You must specificy which serializer to use with the `serializer` option.
-
-```ruby
-class SongSerializer < Oj::Serializer
-  has_one :album, serializer: AlbumSerializer
-  has_many :composers, serializer: ComposerSerializer
-
-  # You can also compose serializers using `flat_one`.
-  flat_one :song, serializer: SongMetadataSerializer
-end
-```
-
-The associations DSL is more concise and achieves better performance, so prefer to use it instead of manually definining attributes:
-
-```ruby
-class SongSerializer < SongMetadataSerializer
-  attribute \
-  def album
-    AlbumSerializer.one(song.album)
-  end
-
-  attribute \
-  def composers
-    ComposerSerializer.many(song.composers)
-  end
-end
-```
-
-## Other DSL 🛠
-
-### Using a different alias for the internal object
-
-You can use `object_as` to create an alias for the serialized object to access it from instance methods:
-
-```ruby
-class DiscographySerializer < Oj::Serializer
-  object_as :artist
-
-  # Now we can use `artist` instead of `object` or `discography`.
-  def latest_albums
-    artist.albums.desc(:year)
-  end
-end
-```
-
-### Rendering an attribute conditionally
-
-All the attributes and association methods can take an `if` option to render conditionally.
-
-```ruby
-class AlbumSerializer < Oj::Serializer
-  mongo_attributes :release_date, if: -> { album.released? }
-
-  has_many :songs, serializer: SongSerializer, if: -> { album.songs.any? }
-
-  # You can achieve the same by manually defining a method:
-  def include_songs?
-    album.songs.any?
-  end
-end
-```
-
-### Memoization & Local State
-
-Serializers are designed to be stateless so that an instanced can be reused, but sometimes it's convenient to store intermediate calculations.
-
-Use `memo` for memoization and storing temporary information.
-
-```ruby
-class DownloadSerializer < Oj::Serializer
-  attributes :filename, :size
-
-  attribute \
-  def progress
-    "#{ last_event&.progress || 0 }%"
-  end
-
-private
-
-  def last_event
-    memo.fetch(:last_event) {
-      download.events.desc(:created_at).first
-    }
-  end
-end
-```
-
-### Render to Hash
-
-In cases where you need objects instead of a JSON string, you can use `render_as_hash`:
-
-```ruby
-album = Album.find(params[:id])
-AlbumSerializer.render_as_hash(album)
-# {name: "Abraxas", genres: ["Pyschodelic Rock", "Blues Rock", ...
-
-albums = Album.all
-PersonSerializer.render_as_hash(albums)
-# [{name: "Abraxas", genres: ["Pyschodelic Rock", "Blues Rock", ...
-```
-
-<details>
-  <summary>Example Output</summary>
-
-```ruby
-{
-  name: "Abraxas",
-  genres: [
-    "Pyschodelic Rock",
-    "Blues Rock",
-    "Jazz Fusion",
-    "Latin Rock",
-  ],
-  release: "September 23, 1970",
-  songs: [
-    {
-      track: 1,
-      name: "Sing Winds, Crying Beasts",
-      composers: ["Michael Carabello"],
-    },
-    {
-      track: 2,
-      name: "Black Magic Woman / Gypsy Queen",
-      composers: ["Peter Green", "Gábor Szabó"],
-    },
-    {
-      track: 3,
-      name: "Oye como va",
-      composers: ["Tito Puente"],
-    },
-    {
-      track: 4,
-      name: "Incident at Neshabur",
-      composers: ["Alberto Gianquinto", "Carlos Santana"],
-    },
-    {
-      track: 5,
-      name: "Se acabó",
-      composers: ["José Areas"],
-    },
-    {
-      track: 6,
-      name: "Mother's Daughter",
-      composers: ["Gregg Rolie"],
-    },
-    {
-      track: 7,
-      name: "Samba pa ti",
-      composers: ["Santana"],
-    },
-    {
-      track: 8,
-      name: "Hope You're Feeling Better",
-      composers: ["Rolie"],
-    },
-    {
-      track: 9,
-      name: "El Nicoya",
-      composers: ["Areas"],
-    },
-  ],
-}
-```
-</details>
-
-Have in mind that building a hash is typically less performant than writing to a
-string directly, as more objects are allocated, so prefer using the [Render DSL]
-whenever possible.
-
-### Caching 📦
-
-Use `cached` to leverage key-based caching, which calls `cache_key` in the object. You can also provide a lambda to `cached_with_key` to define a custom key:
-
-```ruby
-class CachedUserSerializer < UserSerializer
-  cached_with_key ->(user) {
-    "#{ user.id }/#{ user.current_sign_in_at }"
-  }
-end
-```
-
-It will leverage `fetch_multi` when serializing a collection with `many` or `has_many`, to minimize the amount of round trips needed to read and write all items to cache. This works specially well if your cache store also supports `write_multi`.
-
-Usually serialization happens so fast that __turning caching on can be slower__. Always benchmark to make sure it's worth it, and use caching only for time-consuming or deeply nested structures.
-
 ## Design 📐
 
 Unlike `ActiveModel::Serializer`, which builds a Hash that then gets encoded to
@@ -508,16 +507,17 @@ to use, while keeping memory usage under control.
 
 `ActiveModel::Serializer` instantiates one serializer object per item to be serialized.
 
-Other libraries such as [`jsonapi-serializer`][jsonapi] evaluate serializers in the context of
-a `class` instead of an `instance` of a class. Although it is efficient in terms
-of memory usage, the downside is that you can't use instance methods or local
-memoization, and any mixins must be applied to the class itself.
+Other libraries such as [`blueprinter`][blueprinter] [`jsonapi-serializer`][jsonapi]
+evaluate serializers in the context of a `class` instead of an `instance` of a class.
+The downside is that you can't use instance methods or local memoization, and any
+mixins must be applied to the class itself.
 
 [`panko-serializer`][panko] also uses `Oj::StringWriter`, but it has the big downside of having to own the entire render tree. Putting a serializer inside a Hash or an Active Model Serializer and serializing that to JSON doesn't work, making a gradual migration harder to achieve. Also, it's optimized for Active Record but I needed good Mongoid support.
 
 `Oj::Serializer` combines some of these ideas, by using instances, but reusing them to avoid object allocations. Serializing 10,000 items instantiates a single serializer. Unlike `panko-serializer`, it doesn't suffer from [double encoding problems](https://panko.dev/docs/response-bag) so it's easier to use.
 
-As a result, migrating from `active_model_serializers` is relatively straightforward because instance methods, inheritance, and mixins work as usual.
+As a result, migrating from `active_model_serializers` is relatively
+straightforward because instance methods, inheritance, and mixins work as usual.
 
 ## Formatting 📏
 

--- a/README.md
+++ b/README.md
@@ -218,11 +218,11 @@ maintainable.
 
 Obtains the attribute value by calling a method defined in the serializer.
 
-Simply call `serialize` right before defining the method, and it will be serialized:
+Simply call `attribute` right before defining the method, and it will be serialized:
 
 ```ruby
 class PlayerSerializer < Oj::Serializer
-  serialize
+  attribute
   def full_name
     "#{player.first_name} #{player.last_name}"
   end
@@ -307,12 +307,12 @@ The associations DSL is essentially a shortcut for defining attributes manually:
 
 ```ruby
 class SongSerializer < SongMetadataSerializer
-  serialize
+  attribute
   def album
     AlbumSerializer.one(song.album)
   end
 
-  serialize
+  attribute
   def composers
     ComposerSerializer.many(song.composers)
   end
@@ -330,7 +330,7 @@ class DiscographySerializer < Oj::Serializer
   object_as :artist
 
   # Now we can use `artist` instead of `object` or `discography`.
-  serialize
+  attribute
   def latest_albums
     artist.albums.desc(:year)
   end
@@ -346,7 +346,7 @@ using a different key:
 class SongSerializer < Oj::Serializer
   has_one :album, as: :latest_album, serializer: AlbumSerializer
 
-  attribute :title, as: :name
+  attributes title: {as: :name}
 end
 ```
 
@@ -377,7 +377,7 @@ Use `memo` for memoization and storing temporary information.
 class DownloadSerializer < Oj::Serializer
   attributes :filename, :size
 
-  serialize
+  attribute
   def progress
     "#{ last_event&.progress || 0 }%"
   end

--- a/README.md
+++ b/README.md
@@ -239,8 +239,7 @@ In case you need to pass options, you can call the serializer manually:
 
 ```ruby
 class SongSerializer < Oj::Serializer
-  attribute
-  def album
+  attribute :album do
     AlbumSerializer.one(song.album, for_song: song)
   end
 end
@@ -368,7 +367,7 @@ One slight variation that might make it easier to maintain in the long term is
 to use a separate singleton service to provide the url helpers and options, and
 make it available as `urls`.
 
-### Memoization & Local State
+### Memoization & local state
 
 Serializers are designed to be stateless so that an instanced can be reused, but
 sometimes it's convenient to store intermediate calculations.
@@ -404,7 +403,7 @@ class PersonSerializer < Oj::Serializer
 end
 
 PersonSerializer.one('first_name' => 'Mary', :middle_name => 'Jane', :last_name => 'Watson')
-# {"first_name":"Mary","last_name":"Watson"}
+# {first_name: "Mary", last_name: "Watson"}
 ```
 
 ### `mongo_attributes` 🚀
@@ -463,12 +462,17 @@ Alternatively, you can toggle this mode at a serializer level by using
 
 ```ruby
 class BaseSerializer < Oj::Serializer
-  default_format :json # :hash is the default
+  default_format :json
 end
 ```
 
 This will change the default shortcuts (`render`, `one`, `one_if`, and `many`),
 so that the serializer writes directly to JSON instead of returning a Hash.
+
+> **Note**
+>
+> This was the default behavior in `oj_serializers` v1, but was replaced with
+`default_format :hash` in v2.
 
 <details>
   <summary>Example Output</summary>
@@ -554,6 +558,8 @@ so that the serializer writes directly to JSON instead of returning a Hash.
 ```
 </details>
 
+Even when using this mode, you can still use rendered values inside arrays,
+hashes, and other serializers, thanks to [the `raw_json` extensions][raw_json].
 
 ## Design 📐
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Oj Serializers
 </p>
 </h1>
 
-JSON serializers for Ruby, built on top of the powerful [`oj`][oj] library.
+Faster JSON serializers for Ruby, built on top of the powerful [`oj`][oj] library.
 
 [oj]: https://github.com/ohler55/oj
 [mongoid]: https://github.com/mongodb/mongoid

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Learn more about [how this library achieves its performance][design].
 ## Features ⚡️
 
 - Declaration syntax similar to Active Model Serializers
-- Reduced memory allocation and [improved performance][benchmarks]
+- Reduced [memory allocation][benchmarks] and [improved performance][benchmarks]
 - Support for `has_one` and `has_many`, compose with `flat_one`
 - Useful development checks to avoid typos and mistakes
 - Integrates nicely with Rails controllers
@@ -66,7 +66,7 @@ attributes should be serialized.
 class AlbumSerializer < Oj::Serializer
   attributes :name, :genres
 
-  serialize
+  attr
   def release
     album.release_date.strftime('%B %d, %Y')
   end
@@ -391,6 +391,29 @@ private
   end
 end
 ```
+### Caching 📦
+
+Use `cached` to leverage key-based caching, which calls `cache_key` in the object.
+
+You can also provide a lambda to `cached_with_key` to define a custom key:
+
+```ruby
+class CachedUserSerializer < UserSerializer
+  cached_with_key ->(user) {
+    "#{ user.id }/#{ user.current_sign_in_at }"
+  }
+end
+```
+
+It will leverage `fetch_multi` when serializing a collection with `many` or
+`has_many`, to minimize the amount of round trips needed to read and write all
+items to cache.
+
+This works specially well if your cache store also supports `write_multi`.
+
+Usually serialization happens so fast that __turning caching on can be slower__.
+Always benchmark to make sure it's worth it, and use caching only for
+time-consuming or deeply nested structures with unpredictable query patterns.
 
 ### Writing directly to JSON
 
@@ -518,6 +541,13 @@ mixins must be applied to the class itself.
 
 As a result, migrating from `active_model_serializers` is relatively
 straightforward because instance methods, inheritance, and mixins work as usual.
+
+### Benchmarks 📊
+
+This library includes some [benchmarks] to compare performance with similar libraries.
+
+See [this pull request](https://github.com/ElMassimo/oj_serializers/pull/9) for a quick comparison,
+or check the CI to see the latest results.
 
 ## Formatting 📏
 

--- a/README.md
+++ b/README.md
@@ -192,7 +192,11 @@ You can serialize custom values by specifying that a method is an `attribute`:
 
 ```ruby
 class PlayerSerializer < Oj::Serializer
-  attributes :first_name, :last_name, :full_name
+  attribute :name do
+    "#{player.first_name} #{player.last_name}"
+  end
+
+  # or
 
   attribute
   def name
@@ -221,7 +225,7 @@ class SongSerializer < Oj::Serializer
 end
 ```
 
-Provide a different value for the association by providing a block:
+Specify a different value for the association by providing a block:
 
 ```ruby
 class SongSerializer < Oj::Serializer
@@ -258,7 +262,7 @@ class SongSerializer < Oj::Serializer
 end
 ```
 
-### Conditional Attributes ❔
+### Conditional attributes ❔
 
 You can render attributes and associations conditionally by using `:if`.
 
@@ -292,7 +296,7 @@ class DiscographySerializer < Oj::Serializer
 end
 ```
 
-### Identifier Attributes
+### Identifier attributes
 
 The `identifier` method allows you to only include an identifier if the record
 or document has been persisted.
@@ -309,7 +313,7 @@ end
 Additionally, identifier fields are always rendered first, even when sorting
 fields alphabetically.
 
-### Transforming Attribute Keys 🗝
+### Transforming attribute keys 🗝
 
 When serialized data will be consumed from a client language that has different
 naming conventions, it can be convenient to transform keys accordingly.
@@ -330,7 +334,7 @@ end
 
 This has no performance impact, as keys will be transformed at load time.
 
-### Sorting Attributes 📶
+### Sorting attributes 📶
 
 By default attributes are rendered in the order they are defined.
 
@@ -345,7 +349,7 @@ end
 
 This has no performance impact, as attributes will be sorted at load time.
 
-### Path Helpers 🛣
+### Path helpers 🛣
 
 In case you need to access path helpers in your serializers, you can use the
 following:
@@ -420,7 +424,18 @@ end
 
 ### Caching 📦
 
-Use `cached` to leverage key-based caching, which calls `cache_key` in the object.
+Usually rendering is so fast that __turning caching on can be slower__.
+
+However, in cases of deeply nested structures, unpredictable query patterns, or
+methods that take a long time to run, caching can improve performance.
+
+To enable caching, use `cached`, which calls `cache_key` in the object:
+
+```ruby
+class CachedUserSerializer < UserSerializer
+  cached
+end
+```
 
 You can also provide a lambda to `cached_with_key` to define a custom key:
 
@@ -437,10 +452,6 @@ It will leverage `fetch_multi` when serializing a collection with `many` or
 items to cache.
 
 This works specially well if your cache store also supports `write_multi`.
-
-Usually serialization happens so fast that __turning caching on can be slower__.
-Always benchmark to make sure it's worth it, and use caching only for
-time-consuming or deeply nested structures with unpredictable query patterns.
 
 ### Writing to JSON
 
@@ -584,9 +595,9 @@ or check the CI to see the latest results.
 
 ### Migrating from other libraries
 
-This library provides a few different compatibility modes that make it
-easier to migrate from `active_model_serializers` and similar libraries, please
-refer to the [migration guide] for a full discussion.
+Please refer to the [migration guide] for a full discussion of the compatibility
+modes available to make it easier to migrate from `active_model_serializers` and
+similar libraries.
 
 ## Formatting 📏
 

--- a/benchmarks/album_serializer_benchmark.rb
+++ b/benchmarks/album_serializer_benchmark.rb
@@ -4,13 +4,13 @@ require 'benchmark_helper'
 
 RSpec.describe 'AlbumSerializer', :benchmark do
   context 'albums' do
-    before(:all) do |variable|
+    before(:all) do
       album = Album.abraxas
       output = AlbumSerializer.one(album, special: true).to_json
       expect(output).to eq LegacyAlbumSerializer.new(album, special: true).to_json
       expect(output).to eq AlbumBlueprint.render(album, special: true)
       expect(JSON.parse(output)).to eq JSON.parse AlbumPanko.new(context: { special: true }).serialize_to_json(album)
-      expect(JSON.parse(output)).to eq JSON.parse AlbumAlba.new(album, params: {special: true}).serialize
+      expect(JSON.parse(output)).to eq JSON.parse AlbumAlba.new(album, params: { special: true }).serialize
     end
 
     it 'serializing a model' do

--- a/benchmarks/album_serializer_benchmark.rb
+++ b/benchmarks/album_serializer_benchmark.rb
@@ -4,12 +4,8 @@ require 'benchmark_helper'
 
 RSpec.describe 'AlbumSerializer', :benchmark do
   context 'albums' do
-    let(:album) { Album.abraxas }
-    let!(:albums) do
-      100.times.map { Album.abraxas }
-    end
-
     it 'serializing a model' do
+      album = Album.abraxas
       expect(AlbumSerializer.one(album, special: true).to_json).to eq LegacyAlbumSerializer.new(album, special: true).to_json
       expect(AlbumSerializer.one(album, special: true).to_json).to eq AlbumBlueprint.render(album, special: true)
       Benchmark.ips do |x|
@@ -31,6 +27,27 @@ RSpec.describe 'AlbumSerializer', :benchmark do
     end
 
     it 'serializing a collection' do
+      albums = 100.times.map { Album.abraxas }
+      Benchmark.ips do |x|
+        x.config(time: 5, warmup: 2)
+        x.report('oj_serializers') do
+          Oj.dump AlbumSerializer.many_as_json(albums)
+        end
+        x.report('oj_serializers as_hash') do
+          Oj.dump AlbumSerializer.many_as_hash(albums)
+        end
+        x.report('blueprinter') do
+          AlbumBlueprint.render(albums)
+        end
+        x.report('active_model_serializers') do
+          Oj.dump(albums.map { |album| LegacyAlbumSerializer.new(album) })
+        end
+        x.compare!
+      end
+    end
+
+    it 'serializing a large collection' do
+      albums = 1000.times.map { Album.abraxas }
       Benchmark.ips do |x|
         x.config(time: 5, warmup: 2)
         x.report('oj_serializers') do

--- a/benchmarks/album_serializer_benchmark.rb
+++ b/benchmarks/album_serializer_benchmark.rb
@@ -4,23 +4,36 @@ require 'benchmark_helper'
 
 RSpec.describe 'AlbumSerializer', :benchmark do
   context 'albums' do
+    before(:all) do |variable|
+      album = Album.abraxas
+      output = AlbumSerializer.one(album, special: true).to_json
+      expect(output).to eq LegacyAlbumSerializer.new(album, special: true).to_json
+      expect(output).to eq AlbumBlueprint.render(album, special: true)
+      expect(JSON.parse(output)).to eq JSON.parse AlbumPanko.new(context: { special: true }).serialize_to_json(album)
+      expect(JSON.parse(output)).to eq JSON.parse AlbumAlba.new(album, params: {special: true}).serialize
+    end
+
     it 'serializing a model' do
       album = Album.abraxas
-      expect(AlbumSerializer.one(album, special: true).to_json).to eq LegacyAlbumSerializer.new(album, special: true).to_json
-      expect(AlbumSerializer.one(album, special: true).to_json).to eq AlbumBlueprint.render(album, special: true)
       Benchmark.ips do |x|
         x.config(time: 5, warmup: 2)
+        x.report('oj_serializers as_hash') do
+          Oj.dump AlbumSerializer.one_as_hash(album)
+        end
         x.report('oj_serializers') do
           Oj.dump AlbumSerializer.one_as_json(album)
         end
-        x.report('oj_serializers as_hash') do
-          Oj.dump AlbumSerializer.one_as_hash(album)
+        x.report('panko') do
+          AlbumPanko.new.serialize_to_json(album)
         end
         x.report('blueprinter') do
           AlbumBlueprint.render(album)
         end
         x.report('active_model_serializers') do
           Oj.dump LegacyAlbumSerializer.new(album)
+        end
+        x.report('alba') do
+          AlbumAlba.new(album).serialize
         end
         x.compare!
       end
@@ -30,17 +43,23 @@ RSpec.describe 'AlbumSerializer', :benchmark do
       albums = 100.times.map { Album.abraxas }
       Benchmark.ips do |x|
         x.config(time: 5, warmup: 2)
+        x.report('oj_serializers as_hash') do
+          Oj.dump AlbumSerializer.many_as_hash(albums)
+        end
         x.report('oj_serializers') do
           Oj.dump AlbumSerializer.many_as_json(albums)
         end
-        x.report('oj_serializers as_hash') do
-          Oj.dump AlbumSerializer.many_as_hash(albums)
+        x.report('panko') do
+          Panko::ArraySerializer.new(albums, each_serializer: AlbumPanko).to_json
         end
         x.report('blueprinter') do
           AlbumBlueprint.render(albums)
         end
         x.report('active_model_serializers') do
           Oj.dump(albums.map { |album| LegacyAlbumSerializer.new(album) })
+        end
+        x.report('alba') do
+          AlbumAlba.new(albums).serialize
         end
         x.compare!
       end
@@ -50,17 +69,23 @@ RSpec.describe 'AlbumSerializer', :benchmark do
       albums = 1000.times.map { Album.abraxas }
       Benchmark.ips do |x|
         x.config(time: 5, warmup: 2)
+        x.report('oj_serializers as_hash') do
+          Oj.dump AlbumSerializer.many_as_hash(albums)
+        end
         x.report('oj_serializers') do
           Oj.dump AlbumSerializer.many_as_json(albums)
         end
-        x.report('oj_serializers as_hash') do
-          Oj.dump AlbumSerializer.many_as_hash(albums)
+        x.report('panko') do
+          Panko::ArraySerializer.new(albums, each_serializer: AlbumPanko).to_json
         end
         x.report('blueprinter') do
           AlbumBlueprint.render(albums)
         end
         x.report('active_model_serializers') do
           Oj.dump(albums.map { |album| LegacyAlbumSerializer.new(album) })
+        end
+        x.report('alba') do
+          AlbumAlba.new(albums).serialize
         end
         x.compare!
       end

--- a/benchmarks/album_serializer_benchmark.rb
+++ b/benchmarks/album_serializer_benchmark.rb
@@ -2,15 +2,7 @@
 
 require 'benchmark_helper'
 
-require 'rails'
-require 'active_support/json'
-require 'oj_serializers/compat'
-require 'support/serializers/active_model_serializer'
-require 'support/serializers/album_serializer'
-require 'support/serializers/legacy_serializers'
-require 'support/models/album'
-
-RSpec.describe AlbumSerializer, category: :benchmark do
+RSpec.describe 'AlbumSerializer', :benchmark do
   context 'albums' do
     let(:album) { Album.abraxas }
     let!(:albums) do
@@ -19,10 +11,17 @@ RSpec.describe AlbumSerializer, category: :benchmark do
 
     it 'serializing a model' do
       expect(AlbumSerializer.one(album, special: true).to_json).to eq LegacyAlbumSerializer.new(album, special: true).to_json
+      expect(AlbumSerializer.one(album, special: true).to_json).to eq AlbumBlueprint.render(album, special: true)
       Benchmark.ips do |x|
         x.config(time: 5, warmup: 2)
         x.report('oj_serializers') do
-          Oj.dump AlbumSerializer.one(album)
+          Oj.dump AlbumSerializer.one_as_json(album)
+        end
+        x.report('oj_serializers as_hash') do
+          Oj.dump AlbumSerializer.one_as_hash(album)
+        end
+        x.report('blueprinter') do
+          AlbumBlueprint.render(album)
         end
         x.report('active_model_serializers') do
           Oj.dump LegacyAlbumSerializer.new(album)
@@ -35,7 +34,13 @@ RSpec.describe AlbumSerializer, category: :benchmark do
       Benchmark.ips do |x|
         x.config(time: 5, warmup: 2)
         x.report('oj_serializers') do
-          Oj.dump AlbumSerializer.many(albums)
+          Oj.dump AlbumSerializer.many_as_json(albums)
+        end
+        x.report('oj_serializers as_hash') do
+          Oj.dump AlbumSerializer.many_as_hash(albums)
+        end
+        x.report('blueprinter') do
+          AlbumBlueprint.render(albums)
         end
         x.report('active_model_serializers') do
           Oj.dump(albums.map { |album| LegacyAlbumSerializer.new(album) })

--- a/benchmarks/document_benchmark.rb
+++ b/benchmarks/document_benchmark.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
 require 'benchmark_helper'
-require 'support/models/album'
 
-RSpec.describe 'Document Accessors', category: :benchmark do
+RSpec.describe 'Document Accessors', :benchmark do
   let(:album) { Album.abraxas }
 
   it 'getters performance' do

--- a/benchmarks/game_serializer_benchmark.rb
+++ b/benchmarks/game_serializer_benchmark.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'benchmark_helper'
+require 'support/models/sql'
+
+class PlayerPanko < Panko::Serializer
+  attributes :id, :first_name, :last_name, :full_name
+
+  def id
+    object.id if object.persisted?
+  end
+
+  def full_name
+    object.full_name
+  end
+end
+
+# NOTE: This example is quite contrived. Finding good test cases is as hard as
+# finding good names.
+class ScoresPanko < Panko::Serializer
+  attributes :high_score, :score
+end
+
+class GamePanko < Panko::Serializer
+  attributes :id, :name
+
+  has_one :scores, serializer: ScoresPanko
+
+  has_one :best_player, serializer: PlayerPanko
+  has_many :players, serializer: PlayerPanko
+
+  def id
+    object.id if object.persisted?
+  end
+end
+
+Game.prepend Module.new {
+  def scores
+    self
+  end
+}
+
+RSpec.describe 'GameSerializer', :benchmark do
+  context 'albums' do
+    it 'serializing a model' do
+      game = Game.example
+
+      Benchmark.ips do |x|
+        x.config(time: 5, warmup: 2)
+        x.report('oj_serializers as_hash') do
+          Oj.dump GameSerializer.one_as_hash(game)
+        end
+        x.report('oj_serializers') do
+          Oj.dump GameSerializer.one_as_json(game)
+        end
+        x.report('panko') do
+          GamePanko.new.serialize_to_json(game)
+        end
+        x.compare!
+      end
+    end
+  end
+end

--- a/benchmarks/game_serializer_benchmark.rb
+++ b/benchmarks/game_serializer_benchmark.rb
@@ -34,11 +34,11 @@ class GamePanko < Panko::Serializer
   end
 end
 
-Game.prepend Module.new {
+Game.prepend(Module.new {
   def scores
     self
   end
-}
+})
 
 RSpec.describe 'GameSerializer', :benchmark do
   context 'albums' do

--- a/benchmarks/memory_usage_benchmark.rb
+++ b/benchmarks/memory_usage_benchmark.rb
@@ -19,10 +19,10 @@ RSpec.describe 'Memory Usage', :benchmark do
   it 'should require less memory when serializing an object' do
     album
     report = Benchmark.memory do |x|
-      x.report("oj") { Oj.dump AlbumSerializer.one_as_json(album) }
-      x.report("oj_hash") { Oj.dump AlbumSerializer.one_as_hash(album) }
-      x.report("ams") { Oj.dump LegacyAlbumSerializer.new(album) }
-      x.report("blueprinter") { AlbumBlueprint.render(album) }
+      x.report('oj') { Oj.dump AlbumSerializer.one_as_json(album) }
+      x.report('oj_hash') { Oj.dump AlbumSerializer.one_as_hash(album) }
+      x.report('ams') { Oj.dump LegacyAlbumSerializer.new(album) }
+      x.report('blueprinter') { AlbumBlueprint.render(album) }
       x.compare!
     end
     entries = report.comparison.entries
@@ -33,10 +33,10 @@ RSpec.describe 'Memory Usage', :benchmark do
   it 'should require less memory when serializing a collection' do
     albums
     report = Benchmark.memory do |x|
-      x.report("oj") { Oj.dump AlbumSerializer.many_as_json(albums) }
-      x.report("oj_hash") { Oj.dump AlbumSerializer.many_as_hash(albums) }
-      x.report("ams") { Oj.dump(albums.map { |album| LegacyAlbumSerializer.new(album) }) }
-      x.report("blueprinter") { AlbumBlueprint.render(albums) }
+      x.report('oj') { Oj.dump AlbumSerializer.many_as_json(albums) }
+      x.report('oj_hash') { Oj.dump AlbumSerializer.many_as_hash(albums) }
+      x.report('ams') { Oj.dump(albums.map { |album| LegacyAlbumSerializer.new(album) }) }
+      x.report('blueprinter') { AlbumBlueprint.render(albums) }
       x.compare!
     end
     entries = report.comparison.entries

--- a/benchmarks/memory_usage_benchmark.rb
+++ b/benchmarks/memory_usage_benchmark.rb
@@ -3,8 +3,8 @@
 require 'benchmark_helper'
 
 RSpec.describe 'Memory Usage', :benchmark do
-  let!(:album) { Album.abraxas.tap(&:attributes) }
-  let!(:albums) do
+  let(:album) { Album.abraxas.tap(&:attributes) }
+  let(:albums) do
     1000.times.map { Album.abraxas.tap(&:attributes) }
   end
 
@@ -12,56 +12,35 @@ RSpec.describe 'Memory Usage', :benchmark do
     AlbumSerializer.send(:instance)
   end
 
-  def format_number(number)
-    whole, decimal = number.to_s.split('.')
-    if whole.to_i < -999 || whole.to_i > 999
-      whole.reverse!.gsub!(/(\d{3})(?=\d)/, '\\1,').reverse!
-    end
-    [whole, decimal].compact.join('.')
-  end
-
-  def report_allocated_bytes
-    MemoryProfiler.report { yield }
-      .allocated_memory_by_class.sum { |data| data[:count] }
+  def allocated_by(entry)
+    entry.measurement.memory.allocated.to_f
   end
 
   it 'should require less memory when serializing an object' do
-    AlbumSerializer.send(:instance)
-
-    oj_bytes = report_allocated_bytes { Oj.dump AlbumSerializer.one_as_json(album) }
-    oj_hash_bytes = report_allocated_bytes { Oj.dump AlbumSerializer.one_as_hash(album) }
-    ams_bytes = report_allocated_bytes { Oj.dump LegacyAlbumSerializer.new(album) }
-    blueprint_bytes = report_allocated_bytes { AlbumBlueprint.render(album) }
-
-    puts "Bytes allocated by ams: #{format_number ams_bytes}"
-    puts "Bytes allocated by blueprinter: #{format_number blueprint_bytes}"
-    puts "Bytes allocated by oj_serializers: #{format_number oj_bytes}"
-    puts "Bytes allocated by oj_serializers (hash): #{format_number oj_hash_bytes}"
-
-    expect(oj_hash_bytes).to be < ams_bytes
-    expect(oj_hash_bytes).to be < blueprint_bytes
-    expect(oj_bytes).to be < ams_bytes
-    expect(oj_bytes).to be < blueprint_bytes
-    expect(oj_bytes / ams_bytes.to_f).to be < 0.365
+    album
+    report = Benchmark.memory do |x|
+      x.report("oj") { Oj.dump AlbumSerializer.one_as_json(album) }
+      x.report("oj_hash") { Oj.dump AlbumSerializer.one_as_hash(album) }
+      x.report("ams") { Oj.dump LegacyAlbumSerializer.new(album) }
+      x.report("blueprinter") { AlbumBlueprint.render(album) }
+      x.compare!
+    end
+    entries = report.comparison.entries
+    expect(entries.map(&:label)).to eq %w[oj_hash oj blueprinter ams]
+    expect(allocated_by(entries.first) / allocated_by(entries.last)).to be < 0.365
   end
 
   it 'should require less memory when serializing a collection' do
-    AlbumSerializer.send(:instance)
-
-    oj_bytes = report_allocated_bytes { Oj.dump AlbumSerializer.many_as_json(albums) }
-    oj_hash_bytes = report_allocated_bytes { Oj.dump AlbumSerializer.many_as_hash(albums) }
-    ams_bytes = report_allocated_bytes { Oj.dump(albums.map { |album| LegacyAlbumSerializer.new(album) }) }
-    blueprint_bytes = report_allocated_bytes { AlbumBlueprint.render(albums) }
-
-    puts "Bytes allocated by ams: #{format_number ams_bytes}"
-    puts "Bytes allocated by blueprinter: #{format_number blueprint_bytes}"
-    puts "Bytes allocated by oj_serializers: #{format_number oj_bytes}"
-    puts "Bytes allocated by oj_serializers (hash): #{format_number oj_hash_bytes}"
-
-    expect(oj_hash_bytes).to be < ams_bytes
-    expect(oj_hash_bytes).to be < blueprint_bytes
-    expect(oj_bytes).to be < ams_bytes
-    expect(oj_bytes).to be < blueprint_bytes
-    expect(oj_bytes / ams_bytes.to_f).to be < 0.33
+    albums
+    report = Benchmark.memory do |x|
+      x.report("oj") { Oj.dump AlbumSerializer.many_as_json(albums) }
+      x.report("oj_hash") { Oj.dump AlbumSerializer.many_as_hash(albums) }
+      x.report("ams") { Oj.dump(albums.map { |album| LegacyAlbumSerializer.new(album) }) }
+      x.report("blueprinter") { AlbumBlueprint.render(albums) }
+      x.compare!
+    end
+    entries = report.comparison.entries
+    expect(entries.map(&:label)).to eq %w[oj oj_hash blueprinter ams]
+    expect(allocated_by(entries.first) / allocated_by(entries.last)).to be < 0.33
   end
 end

--- a/benchmarks/memory_usage_benchmark.rb
+++ b/benchmarks/memory_usage_benchmark.rb
@@ -9,7 +9,9 @@ RSpec.describe 'Memory Usage', :benchmark do
   end
 
   before do
-    AlbumSerializer.send(:instance)
+    AlbumSerializer.one_as_hash(album)
+    LegacyAlbumSerializer.new(album).to_json
+    AlbumBlueprint.render(album)
   end
 
   def allocated_by(entry)
@@ -26,7 +28,9 @@ RSpec.describe 'Memory Usage', :benchmark do
       x.compare!
     end
     entries = report.comparison.entries
-    expect(entries.map(&:label)).to eq %w[oj_hash oj blueprinter ams]
+    oj1, oj2, *rest = entries.map(&:label)
+    expect([oj1, oj2]).to contain_exactly(*%w[oj_hash oj])
+    expect(rest).to eq %w[blueprinter ams]
     expect(allocated_by(entries.first) / allocated_by(entries.last)).to be < 0.365
   end
 

--- a/benchmarks/memory_usage_benchmark.rb
+++ b/benchmarks/memory_usage_benchmark.rb
@@ -12,6 +12,8 @@ RSpec.describe 'Memory Usage', :benchmark do
     AlbumSerializer.one_as_hash(album)
     LegacyAlbumSerializer.new(album).to_json
     AlbumBlueprint.render(album)
+    AlbumAlba.new(album).serialize
+    AlbumPanko.new.serialize_to_json(album)
   end
 
   def allocated_by(entry)
@@ -24,13 +26,15 @@ RSpec.describe 'Memory Usage', :benchmark do
       x.report('oj') { Oj.dump AlbumSerializer.one_as_json(album) }
       x.report('oj_hash') { Oj.dump AlbumSerializer.one_as_hash(album) }
       x.report('ams') { Oj.dump LegacyAlbumSerializer.new(album) }
+      x.report('alba') { AlbumAlba.new(album).serialize }
+      x.report('panko') { AlbumPanko.new.serialize_to_json(album) }
       x.report('blueprinter') { AlbumBlueprint.render(album) }
       x.compare!
     end
     entries = report.comparison.entries
     oj1, oj2, *rest = entries.map(&:label)
     expect([oj1, oj2]).to contain_exactly(*%w[oj_hash oj])
-    expect(rest).to eq %w[blueprinter ams]
+    expect(rest).to eq %w[panko blueprinter ams alba]
     expect(allocated_by(entries.first) / allocated_by(entries.last)).to be < 0.365
   end
 
@@ -40,11 +44,13 @@ RSpec.describe 'Memory Usage', :benchmark do
       x.report('oj') { Oj.dump AlbumSerializer.many_as_json(albums) }
       x.report('oj_hash') { Oj.dump AlbumSerializer.many_as_hash(albums) }
       x.report('ams') { Oj.dump(albums.map { |album| LegacyAlbumSerializer.new(album) }) }
+      x.report('alba') { AlbumAlba.new(albums).serialize }
+      x.report('panko') { Panko::ArraySerializer.new(albums, each_serializer: AlbumPanko).to_json }
       x.report('blueprinter') { AlbumBlueprint.render(albums) }
       x.compare!
     end
     entries = report.comparison.entries
-    expect(entries.map(&:label)).to eq %w[oj oj_hash blueprinter ams]
+    expect(entries.map(&:label)).to eq %w[oj oj_hash panko blueprinter ams alba]
     expect(allocated_by(entries.first) / allocated_by(entries.last)).to be < 0.33
   end
 end

--- a/benchmarks/model_serializer_benchmark.rb
+++ b/benchmarks/model_serializer_benchmark.rb
@@ -17,6 +17,12 @@ RSpec.describe 'ModelSerializer', :benchmark do
         x.report('oj_serializers hash') do
           Oj.dump ModelSerializer.many_as_hash(albums)
         end
+        x.report('panko') do
+          Panko::ArraySerializer.new(albums, each_serializer: ModelPanko).to_json
+        end
+        x.report('alba') do
+          ModelAlba.new(albums).serialize
+        end
         x.report('blueprinter') do
           ModelBlueprint.render(albums)
         end

--- a/benchmarks/model_serializer_benchmark.rb
+++ b/benchmarks/model_serializer_benchmark.rb
@@ -2,14 +2,7 @@
 
 require 'benchmark_helper'
 
-require 'rails'
-require 'active_support/json'
-require 'oj_serializers/compat'
-require 'support/serializers/active_model_serializer'
-require 'support/serializers/model_serializer'
-require 'support/models/album'
-
-RSpec.describe ModelSerializer, category: :benchmark do
+RSpec.describe 'ModelSerializer', :benchmark do
   context 'albums' do
     let!(:albums) do
       100.times.map { Album.abraxas }
@@ -20,6 +13,12 @@ RSpec.describe ModelSerializer, category: :benchmark do
         x.config(time: 5, warmup: 2)
         x.report('oj_serializers') do
           Oj.dump ModelSerializer.many(albums)
+        end
+        x.report('oj_serializers hash') do
+          Oj.dump ModelSerializer.many_as_hash(albums)
+        end
+        x.report('blueprinter') do
+          ModelBlueprint.render(albums)
         end
         x.report('active_model_serializers') do
           Oj.dump(albums.map { |album| ActiveModelSerializer.new(album) })

--- a/benchmarks/option_serializer_benchmark.rb
+++ b/benchmarks/option_serializer_benchmark.rb
@@ -10,8 +10,8 @@ RSpec.describe 'OptionSerializer', :benchmark do
 
     it 'serializing models' do
       some = albums.take(1)
-      expect(Oj.dump OptionSerializer::Oj.many(some)).to eq OptionSerializer::Blueprinter.render(some)
-      expect(Oj.dump OptionSerializer::Oj.many(some)).to eq(Oj.dump(some.map { |album| OptionSerializer::AMS.new(album) }))
+      expect(Oj.dump(OptionSerializer::Oj.many(some))).to eq OptionSerializer::Blueprinter.render(some)
+      expect(Oj.dump(OptionSerializer::Oj.many(some))).to eq(Oj.dump(some.map { |album| OptionSerializer::AMS.new(album) }))
 
       Benchmark.ips do |x|
         x.config(time: 5, warmup: 2)

--- a/benchmarks/option_serializer_benchmark.rb
+++ b/benchmarks/option_serializer_benchmark.rb
@@ -9,6 +9,10 @@ RSpec.describe 'OptionSerializer', :benchmark do
     end
 
     it 'serializing models' do
+      some = albums.take(1)
+      expect(Oj.dump OptionSerializer::Oj.many(some)).to eq OptionSerializer::Blueprinter.render(some)
+      expect(Oj.dump OptionSerializer::Oj.many(some)).to eq(Oj.dump(some.map { |album| OptionSerializer::AMS.new(album) }))
+
       Benchmark.ips do |x|
         x.config(time: 5, warmup: 2)
         x.report('oj_serializers') do

--- a/benchmarks/option_serializer_benchmark.rb
+++ b/benchmarks/option_serializer_benchmark.rb
@@ -2,13 +2,7 @@
 
 require 'benchmark_helper'
 
-require 'rails'
-require 'active_support/json'
-require 'oj_serializers/compat'
-require 'support/serializers/option_serializer'
-require 'support/models/album'
-
-RSpec.describe OptionSerializer, category: :benchmark do
+RSpec.describe 'OptionSerializer', :benchmark do
   context 'albums' do
     let!(:albums) do
       100.times.map { Album.abraxas }
@@ -17,17 +11,23 @@ RSpec.describe OptionSerializer, category: :benchmark do
     it 'serializing models' do
       Benchmark.ips do |x|
         x.config(time: 5, warmup: 2)
-        x.report('string_writer') do
-          Oj.dump OptionSerializer.write_models(albums)
-        end
         x.report('oj_serializers') do
           Oj.dump OptionSerializer::Oj.many(albums)
         end
-        x.report('map') do
+        x.report('oj_serializers (hash)') do
+          Oj.dump OptionSerializer::Oj.many_as_hash(albums)
+        end
+        x.report('map_models') do
           Oj.dump OptionSerializer.map_models(albums)
+        end
+        x.report('write_models') do
+          Oj.dump OptionSerializer.write_models(albums)
         end
         x.report('active_model_serializers') do
           Oj.dump(albums.map { |album| OptionSerializer::AMS.new(album) })
+        end
+        x.report('blueprinter') do
+          OptionSerializer::Blueprinter.render(albums)
         end
         x.compare!
       end

--- a/benchmarks/option_serializer_benchmark.rb
+++ b/benchmarks/option_serializer_benchmark.rb
@@ -27,6 +27,12 @@ RSpec.describe 'OptionSerializer', :benchmark do
         x.report('write_models') do
           Oj.dump OptionSerializer.write_models(albums)
         end
+        x.report('alba') do
+          OptionSerializer::Alba.new(albums).serialize
+        end
+        x.report('panko') do
+          Panko::ArraySerializer.new(albums, each_serializer: OptionSerializer::Panko).to_json
+        end
         x.report('active_model_serializers') do
           Oj.dump(albums.map { |album| OptionSerializer::AMS.new(album) })
         end

--- a/benchmarks/record_benchmark.rb
+++ b/benchmarks/record_benchmark.rb
@@ -3,7 +3,7 @@
 require 'benchmark_helper'
 require 'support/models/sql'
 
-RSpec.describe 'Record Accessors', category: :benchmark do
+RSpec.describe 'Record Accessors', :benchmark do
   let(:player) { Game.example.players.first }
 
   it 'getters performance' do

--- a/bin/bundle
+++ b/bin/bundle
@@ -18,7 +18,7 @@ module_function
   end
 
   def env_var_version
-    ENV['BUNDLER_VERSION']
+    ENV.fetch('BUNDLER_VERSION', nil)
   end
 
   def cli_arg_version
@@ -38,7 +38,7 @@ module_function
   end
 
   def gemfile
-    gemfile = ENV['BUNDLE_GEMFILE']
+    gemfile = ENV.fetch('BUNDLE_GEMFILE', nil)
     return gemfile if gemfile && !gemfile.empty?
 
     File.expand_path('../Gemfile', __dir__)

--- a/bin/console
+++ b/bin/console
@@ -15,6 +15,10 @@ def check
   puts AlbumSerializer.send(:code_to_render_as_hash)
 end
 
+def check_json
+  puts AlbumSerializer.send(:code_to_write_to_json)
+end
+
 def axs
   AlbumSerializer.one Album.abraxas
 end

--- a/bin/console
+++ b/bin/console
@@ -11,4 +11,12 @@ $LOAD_PATH.unshift Pathname.new(__dir__).join('../spec')
 
 Dir[Pathname.new(__dir__).join('../spec/support/**/*.rb')].sort.each { |f| require f }
 
+def check
+  puts AlbumSerializer.send(:render_as_hash_body)
+end
+
+def axs
+  AlbumSerializer.one Album.abraxas
+end
+
 Pry.start

--- a/bin/console
+++ b/bin/console
@@ -12,7 +12,7 @@ $LOAD_PATH.unshift Pathname.new(__dir__).join('../spec')
 Dir[Pathname.new(__dir__).join('../spec/support/**/*.rb')].sort.each { |f| require f }
 
 def check
-  puts AlbumSerializer.send(:render_as_hash_body)
+  puts AlbumSerializer.send(:code_to_render_as_hash)
 end
 
 def axs

--- a/examples/my_api/app/serializers/album_serializer.rb
+++ b/examples/my_api/app/serializers/album_serializer.rb
@@ -7,7 +7,7 @@ class AlbumSerializer < BaseSerializer
     :genres,
   )
 
-  serialize if: -> { album.released? }
+  attribute if: -> { album.released? }
   def release
     album.release_date.strftime('%B %d, %Y')
   end

--- a/examples/my_api/app/serializers/album_serializer.rb
+++ b/examples/my_api/app/serializers/album_serializer.rb
@@ -7,10 +7,10 @@ class AlbumSerializer < BaseSerializer
     :genres,
   )
 
-  has_many :songs, serializer: SongSerializer
-
-  attribute \
+  serialize if: -> { album.released? }
   def release
     album.release_date.strftime('%B %d, %Y')
-  end, if: -> { album.released? }
+  end
+
+  has_many :songs, serializer: SongSerializer
 end

--- a/examples/my_api/app/serializers/song_serializer.rb
+++ b/examples/my_api/app/serializers/song_serializer.rb
@@ -7,7 +7,7 @@ class SongSerializer < BaseSerializer
     :name,
   )
 
-  attribute \
+  serialize
   def composers
     song.composer&.split(', ')
   end

--- a/examples/my_api/app/serializers/song_serializer.rb
+++ b/examples/my_api/app/serializers/song_serializer.rb
@@ -7,7 +7,7 @@ class SongSerializer < BaseSerializer
     :name,
   )
 
-  serialize
+  attribute
   def composers
     song.composer&.split(', ')
   end

--- a/examples/my_api/bin/bundle
+++ b/examples/my_api/bin/bundle
@@ -18,7 +18,7 @@ module_function
   end
 
   def env_var_version
-    ENV['BUNDLER_VERSION']
+    ENV.fetch('BUNDLER_VERSION', nil)
   end
 
   def cli_arg_version
@@ -38,7 +38,7 @@ module_function
   end
 
   def gemfile
-    gemfile = ENV['BUNDLE_GEMFILE']
+    gemfile = ENV.fetch('BUNDLE_GEMFILE', nil)
     return gemfile if gemfile && !gemfile.empty?
 
     File.expand_path('../Gemfile', __dir__)

--- a/examples/my_api/config/environments/production.rb
+++ b/examples/my_api/config/environments/production.rb
@@ -69,14 +69,14 @@ Rails.application.configure do
   config.active_support.deprecation = :notify
 
   # Use default logging formatter so that PID and timestamp are not suppressed.
-  config.log_formatter = ::Logger::Formatter.new
+  config.log_formatter = Logger::Formatter.new
 
   # Use a different logger for distributed setups.
   # require 'syslog/logger'
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
   if ENV['RAILS_LOG_TO_STDOUT'].present?
-    logger           = ActiveSupport::Logger.new(STDOUT)
+    logger           = ActiveSupport::Logger.new($stdout)
     logger.formatter = config.log_formatter
     config.logger    = ActiveSupport::TaggedLogging.new(logger)
   end

--- a/examples/my_api/config/puma.rb
+++ b/examples/my_api/config/puma.rb
@@ -6,20 +6,20 @@
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
 #
-max_threads_count = ENV.fetch('RAILS_MAX_THREADS') { 5 }
+max_threads_count = ENV.fetch('RAILS_MAX_THREADS', 5)
 min_threads_count = ENV.fetch('RAILS_MIN_THREADS') { max_threads_count }
 threads min_threads_count, max_threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests; default is 3000.
 #
-port        ENV.fetch('PORT') { 3000 }
+port        ENV.fetch('PORT', 3000)
 
 # Specifies the `environment` that Puma will run in.
 #
-environment ENV.fetch('RAILS_ENV') { 'development' }
+environment ENV.fetch('RAILS_ENV', 'development')
 
 # Specifies the `pidfile` that Puma will use.
-pidfile ENV.fetch('PIDFILE') { 'tmp/pids/server.pid' }
+pidfile ENV.fetch('PIDFILE', 'tmp/pids/server.pid')
 
 # Specifies the number of `workers` to boot in clustered mode.
 # Workers are forked web server processes. If using threads and workers together

--- a/gemfiles/Gemfile-rails-edge
+++ b/gemfiles/Gemfile-rails-edge
@@ -1,4 +1,6 @@
-eval File.read('Gemfile').sub('gemspec', 'gemspec ".."')
+require_relative "base"
+
+eval main_gemfile
 
 gem 'rails', github: 'rails/rails', branch: 'main'
 gem 'actionpack', github: 'rails/rails', branch: 'main', glob: 'actionpack/*.gemspec'

--- a/gemfiles/Gemfile-rails-edge
+++ b/gemfiles/Gemfile-rails-edge
@@ -1,10 +1,6 @@
-source 'https://rubygems.org'
-
-git_source(:github) { |repo| "https://github.com/#{repo}.git" }
+eval File.read('Gemfile').sub('gemspec', 'gemspec ".."')
 
 gem 'rails', github: 'rails/rails', branch: 'main'
 gem 'actionpack', github: 'rails/rails', branch: 'main', glob: 'actionpack/*.gemspec'
 gem 'activerecord', github: 'rails/rails', branch: 'main', glob: 'activerecord/*.gemspec'
 gem 'railties', github: 'rails/rails', branch: 'main', glob: 'railties/*.gemspec'
-
-gemspec path: '..'

--- a/gemfiles/Gemfile-rails.6.1.x
+++ b/gemfiles/Gemfile-rails.6.1.x
@@ -1,3 +1,5 @@
-eval File.read('Gemfile').sub('gemspec', 'gemspec ".."')
+require_relative "base"
+
+eval main_gemfile
 
 gem 'rails', '~> 6.1.0'

--- a/gemfiles/Gemfile-rails.6.1.x
+++ b/gemfiles/Gemfile-rails.6.1.x
@@ -1,5 +1,3 @@
-source 'https://rubygems.org'
+eval File.read('Gemfile').sub('gemspec', 'gemspec ".."')
 
 gem 'rails', '~> 6.1.0'
-
-gemspec path: '..'

--- a/gemfiles/Gemfile-rails.7.0.x
+++ b/gemfiles/Gemfile-rails.7.0.x
@@ -1,3 +1,5 @@
-eval File.read('Gemfile').sub('gemspec', 'gemspec ".."')
+require_relative "base"
+
+eval main_gemfile
 
 gem 'rails', '~> 7.0.3'

--- a/gemfiles/Gemfile-rails.7.0.x
+++ b/gemfiles/Gemfile-rails.7.0.x
@@ -1,5 +1,3 @@
-source 'https://rubygems.org'
+eval File.read('Gemfile').sub('gemspec', 'gemspec ".."')
 
 gem 'rails', '~> 7.0.3'
-
-gemspec path: '..'

--- a/gemfiles/base.rb
+++ b/gemfiles/base.rb
@@ -1,0 +1,3 @@
+def main_gemfile
+  File.read('Gemfile').sub('gemspec', 'gemspec path: ".."')
+end

--- a/gemfiles/base.rb
+++ b/gemfiles/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 def main_gemfile
   File.read('Gemfile').sub('gemspec', 'gemspec path: ".."')
 end

--- a/gemfiles/base.rb
+++ b/gemfiles/base.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 def main_gemfile
-  "ENV['NO_RAILS'] = 'true'\n" + File.read('Gemfile').sub('gemspec', 'gemspec path: ".."')
+  "ENV['NO_RAILS'] = 'true'\n#{File.read('Gemfile').sub('gemspec', 'gemspec path: ".."')}"
 end

--- a/gemfiles/base.rb
+++ b/gemfiles/base.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 def main_gemfile
-  File.read('Gemfile').sub('gemspec', 'gemspec path: ".."')
+  "ENV['NO_RAILS'] = 'true'\n" + File.read('Gemfile').sub('gemspec', 'gemspec path: ".."')
 end

--- a/lib/oj_serializers/compat.rb
+++ b/lib/oj_serializers/compat.rb
@@ -6,28 +6,13 @@ require 'active_model_serializers'
 # as well.
 class ActiveModel::Serializer
   # JsonStringEncoder: Used internally to write a single object to JSON.
-  #
-  # Returns nothing.
-  def self.write_one(writer, object, options)
-    writer.push_value(new(object, options))
+  def self.one(object, options = nil)
+    new(object, options)
   end
 
   # JsonStringEncoder: Used internally to write an array of objects to JSON.
-  #
-  # Returns nothing.
-  def self.write_many(writer, array, options)
-    writer.push_array
-    array.each do |object|
-      write_one(writer, object, options)
-    end
-    writer.pop
-  end
-
-  # JsonStringEncoder: Used internally to instantiate an Oj::StringWriter.
-  #
-  # Returns an Oj::StringWriter.
-  def self.new_json_writer
-    OjSerializers::Serializer.send(:new_json_writer)
+  def self.many(array, options = nil)
+    array.map { |object| new(object, options) }
   end
 end
 

--- a/lib/oj_serializers/json_string_encoder.rb
+++ b/lib/oj_serializers/json_string_encoder.rb
@@ -24,19 +24,16 @@ module OjSerializers::JsonStringEncoder
       else
         object
       end
-      Oj.dump(root ? {root => result} : result)
+      Oj.dump(root ? { root => result } : result)
     end
 
     if OjSerializers::Serializer::DEV_MODE
       alias actual_encode_to_json encode_to_json
       # Internal: Allows to detect misusage of the options during development.
       def encode_to_json(object, root: nil, serializer: nil, each_serializer: nil, **options)
-        if serializer && serializer < OjSerializers::Serializer
-          raise ArgumentError, 'You must use `each_serializer` when serializing collections' if object.respond_to?(:map)
-        end
-        if each_serializer && each_serializer < OjSerializers::Serializer
-          raise ArgumentError, 'You must use `serializer` when serializing a single object' unless object.respond_to?(:map)
-        end
+        raise ArgumentError, 'You must use `each_serializer` when serializing collections' if serializer && serializer < OjSerializers::Serializer && object.respond_to?(:map)
+        raise ArgumentError, 'You must use `serializer` when serializing a single object' if each_serializer && each_serializer < OjSerializers::Serializer && !object.respond_to?(:map)
+
         actual_encode_to_json(object, root: root, serializer: serializer, each_serializer: each_serializer, **options)
       end
     end

--- a/lib/oj_serializers/json_string_encoder.rb
+++ b/lib/oj_serializers/json_string_encoder.rb
@@ -14,43 +14,30 @@ module OjSerializers::JsonStringEncoder
     # regardless of whether a serializer is specified or not.
     #
     # Returns a JSON string.
-    def encode_to_json(object, root: nil, serializer: nil, each_serializer: nil, **extras)
-      # NOTE: Serializers may override `new_json_writer` to modify the behavior.
-      writer = (serializer || each_serializer || OjSerializers::Serializer).send(:new_json_writer)
-
-      if root
-        writer.push_object
-        writer.push_key(root.to_s)
-      end
-
-      if serializer
-        serializer.write_one(writer, object, extras)
+    def encode_to_json(object, root: nil, serializer: nil, each_serializer: nil, **options)
+      result = if serializer
+        serializer.one(object, options)
       elsif each_serializer
-        each_serializer.write_many(writer, object, extras)
+        each_serializer.many(object, options)
       elsif object.is_a?(String)
-        return object unless root
-
-        writer.push_json(object)
+        OjSerializers::JsonValue.new(object)
       else
-        writer.push_value(object)
+        object
       end
-
-      writer.pop if root
-
-      writer.to_json
+      Oj.dump(root ? {root => result} : result)
     end
 
     if OjSerializers::Serializer::DEV_MODE
       alias actual_encode_to_json encode_to_json
       # Internal: Allows to detect misusage of the options during development.
-      def encode_to_json(object, root: nil, serializer: nil, each_serializer: nil, **extras)
+      def encode_to_json(object, root: nil, serializer: nil, each_serializer: nil, **options)
         if serializer && serializer < OjSerializers::Serializer
-          raise ArgumentError, 'You must use `each_serializer` when serializing collections' if object.respond_to?(:each)
+          raise ArgumentError, 'You must use `each_serializer` when serializing collections' if object.respond_to?(:map)
         end
         if each_serializer && each_serializer < OjSerializers::Serializer
-          raise ArgumentError, 'You must use `serializer` when serializing a single object' unless object.respond_to?(:each)
+          raise ArgumentError, 'You must use `serializer` when serializing a single object' unless object.respond_to?(:map)
         end
-        actual_encode_to_json(object, root: root, serializer: serializer, each_serializer: each_serializer, **extras)
+        actual_encode_to_json(object, root: root, serializer: serializer, each_serializer: each_serializer, **options)
       end
     end
   end

--- a/lib/oj_serializers/serializer.rb
+++ b/lib/oj_serializers/serializer.rb
@@ -40,25 +40,12 @@ class OjSerializers::Serializer
 
   # NOTE: Helps developers to remember to keep serializers stateless.
   if DEV_MODE
-    prepend(Module.new do
-      def write_to_json(writer, item, options = nil)
-        super.tap do
-          if instance_values.keys.any? { |key| !ALLOWED_INSTANCE_VARIABLES.include?(key) }
-            bad_keys = instance_values.keys.reject { |key| ALLOWED_INSTANCE_VARIABLES.include?(key) }
-            raise ArgumentError, "Serializer instances are reused so they must be stateless. Use `memo.fetch` for memoization purposes instead. Bad keys: #{bad_keys.join(',')}"
-          end
-        end
+    def _check_instance_variables
+      if instance_values.keys.any? { |key| !ALLOWED_INSTANCE_VARIABLES.include?(key) }
+        bad_keys = instance_values.keys.reject { |key| ALLOWED_INSTANCE_VARIABLES.include?(key) }
+        raise ArgumentError, "Serializer instances are reused so they must be stateless. Use `memo.fetch` for memoization purposes instead. Bad keys: #{bad_keys.join(',')}"
       end
-
-      def render_as_hash(item, options = nil)
-        super.tap do
-          if instance_values.keys.any? { |key| !ALLOWED_INSTANCE_VARIABLES.include?(key) }
-            bad_keys = instance_values.keys.reject { |key| ALLOWED_INSTANCE_VARIABLES.include?(key) }
-            raise ArgumentError, "Serializer instances are reused so they must be stateless. Use `memo.fetch` for memoization purposes instead. Bad keys: #{bad_keys.join(',')}"
-          end
-        end
-      end
-    end)
+    end
   end
 
   # Internal: Used internally to write a single object to JSON.
@@ -430,6 +417,8 @@ private
           else
             raise e
           end
+        ensure
+          _check_instance_variables
       RESCUE_NO_METHOD
     end
 

--- a/lib/oj_serializers/serializer.rb
+++ b/lib/oj_serializers/serializer.rb
@@ -199,7 +199,7 @@ protected
     # Internal: Will alias the object according to the name of the wrapper class.
     def inherited(subclass)
       object_alias = subclass.name.demodulize.chomp('Serializer').underscore
-      subclass.object_as(object_alias) unless method_defined?(object_alias) || object_alias == "base"
+      subclass.object_as(object_alias) unless method_defined?(object_alias) || object_alias == 'base'
       super
     end
 

--- a/lib/oj_serializers/serializer.rb
+++ b/lib/oj_serializers/serializer.rb
@@ -92,7 +92,7 @@ protected
 
   # Internal: An internal cache that can be used for temporary memoization.
   def memo
-    defined?(@memo) ? @memo : @memo = OjSerializers::Memo.new
+    @memo ||= OjSerializers::Memo.new
   end
 
 private
@@ -198,7 +198,8 @@ private
     #
     # Returns an Array of Hash, each with the attributes specified in the serializer.
     def many_as_hash(items, options = nil)
-      items.map { |item| instance.render_as_hash(item, options) }
+      serializer = instance
+      items.map { |item| serializer.render_as_hash(item, options) }
     end
 
     # Internal: Will alias the object according to the name of the wrapper class.
@@ -212,8 +213,7 @@ private
     #
     # Any attributes defined in parent classes are inherited.
     def _attributes
-      @_attributes = superclass.try(:_attributes)&.dup || {} unless defined?(@_attributes)
-      @_attributes
+      @_attributes ||= superclass.try(:_attributes)&.dup || {}
     end
 
   protected
@@ -577,13 +577,12 @@ private
 
     # Internal: Cache key to set a thread-local instance.
     def instance_key
-      unless defined?(@instance_key)
-        @instance_key = "#{name.underscore}_instance_#{object_id}".to_sym
+      @instance_key ||= begin
         # We take advantage of the fact that this method will always be called
         # before instantiating a serializer, to apply last minute adjustments.
         _prepare_serializer
+        "#{name.underscore}_instance_#{object_id}".to_sym
       end
-      @instance_key
     end
 
     # Internal: Generates write_to_json and render_as_hash methods optimized for

--- a/lib/oj_serializers/serializer.rb
+++ b/lib/oj_serializers/serializer.rb
@@ -265,7 +265,7 @@ private
         singleton_class.alias_method :one, :"one_as_#{format}"
         singleton_class.alias_method :many, :"many_as_#{format}"
       else
-        raise ArgumentError,  "Unknown serialization format: #{format.inspect}"
+        raise ArgumentError, "Unknown serialization format: #{format.inspect}"
       end
     end
 
@@ -281,12 +281,12 @@ private
 
     # Public: Specify a collection of objects that should be serialized using
     # the specified serializer.
-    def has_many(name, root: name, as: root, serializer:, **options)
+    def has_many(name, serializer:, root: name, as: root, **options)
       add_attribute(name, association: :many, as: as, serializer: serializer, **options)
     end
 
     # Public: Specify an object that should be serialized using the serializer.
-    def has_one(name, root: name, as: root, serializer:, **options)
+    def has_one(name, serializer:, root: name, as: root, **options)
       add_attribute(name, association: :one, as: as, serializer: serializer, **options)
     end
 
@@ -457,15 +457,15 @@ private
     def code_to_rescue_no_method
       <<~RESCUE_NO_METHOD
 
-      rescue NoMethodError => e
-        key = e.name.to_s.inspect
-        message = if respond_to?(e.name)
-          raise e, "Perhaps you meant to call \#{key} in \#{self.class} instead?\nTry using `serializer_attributes :\#{key}` or `attribute def \#{key}`.\n\#{e.message}"
-        elsif @object.respond_to?(e.name)
-          raise e, "Perhaps you meant to call \#{key} in \#{@object.class} instead?\nTry using `attributes :\#{key}`.\n\#{e.message}"
-        else
-          raise e
-        end
+        rescue NoMethodError => e
+          key = e.name.to_s.inspect
+          message = if respond_to?(e.name)
+            raise e, "Perhaps you meant to call \#{key} in \#{self.class} instead?\nTry using `serializer_attributes :\#{key}` or `attribute def \#{key}`.\n\#{e.message}"
+          elsif @object.respond_to?(e.name)
+            raise e, "Perhaps you meant to call \#{key} in \#{@object.class} instead?\nTry using `attributes :\#{key}`.\n\#{e.message}"
+          else
+            raise e
+          end
       RESCUE_NO_METHOD
     end
 
@@ -497,19 +497,19 @@ private
       case type = options.fetch(:association)
       when :one
         <<~WRITE_ONE
-        if associated_object = #{association_method}
-          writer.push_key('#{key}')
-          #{serializer_class}.write_one(writer, associated_object)
-        end
+          if associated_object = #{association_method}
+            writer.push_key('#{key}')
+            #{serializer_class}.write_one(writer, associated_object)
+          end
         WRITE_ONE
       when :many
         <<~WRITE_MANY
-        writer.push_key('#{key}')
-        #{serializer_class}.write_many(writer, #{association_method})
+          writer.push_key('#{key}')
+          #{serializer_class}.write_many(writer, #{association_method})
         WRITE_MANY
       when :flat
         <<~WRITE_FLAT
-        #{serializer_class}.write_flat(writer, #{association_method})
+          #{serializer_class}.write_flat(writer, #{association_method})
         WRITE_FLAT
       else
         raise ArgumentError, "Unknown association type: #{type.inspect}"

--- a/lib/oj_serializers/serializer.rb
+++ b/lib/oj_serializers/serializer.rb
@@ -266,11 +266,10 @@ protected
       add_attributes(method_names, **attr_options, attribute: :method)
 
       methods_with_options.each do |name, options|
-        options = {as: options} if options.is_a?(Symbol)
+        options = { as: options } if options.is_a?(Symbol)
         add_attribute(name, options)
       end
     end
-    alias_method :attribute, :attributes
 
     # Public: Specify which attributes are going to be obtained by calling a
     # method in the serializer.

--- a/lib/oj_serializers/serializer.rb
+++ b/lib/oj_serializers/serializer.rb
@@ -82,8 +82,6 @@ protected
     @memo ||= OjSerializers::Memo.new
   end
 
-private
-
   class << self
     # Public: Allows the user to specify `default_format :json`, as a simple
     # way to ensure that `.one` and `.many` work as in Version 1.

--- a/lib/oj_serializers/serializer.rb
+++ b/lib/oj_serializers/serializer.rb
@@ -43,7 +43,7 @@ class OjSerializers::Serializer
     def _check_instance_variables
       if instance_values.keys.any? { |key| !ALLOWED_INSTANCE_VARIABLES.include?(key) }
         bad_keys = instance_values.keys.reject { |key| ALLOWED_INSTANCE_VARIABLES.include?(key) }
-        raise ArgumentError, "Serializer instances are reused so they must be stateless. Use `memo.fetch` for memoization purposes instead. Bad keys: #{bad_keys.join(',')}"
+        raise ArgumentError, "Serializer instances are reused so they must be stateless. Use `memo.fetch` for memoization purposes instead. Bad keys: #{bad_keys.join(',')} in #{self.class}"
       end
     end
   end
@@ -532,7 +532,7 @@ protected
     # Internal: Detects any include methods defined in the serializer, or defines
     # one by using the lambda passed in the `if` option, if any.
     def check_conditional_method(method_name, options)
-      include_method_name = "include_#{method_name}#{'?' unless method_name.ends_with?('?')}"
+      include_method_name = "include_#{method_name}#{'?' unless method_name.to_s.ends_with?('?')}"
       if render_if = options[:if]
         if render_if.is_a?(Symbol)
           alias_method(include_method_name, render_if)

--- a/lib/oj_serializers/serializer.rb
+++ b/lib/oj_serializers/serializer.rb
@@ -233,6 +233,8 @@ protected
     def has_one(name, serializer:, root: name, as: root, **options)
       add_attribute(name, association: :one, as: as, serializer: serializer, **options)
     end
+    # Alias: From a serializer perspective, the association type does not matter.
+    alias_method :belongs_to, :has_one
 
     # Public: Specify an object that should be serialized using the serializer,
     # but unlike `has_one`, this one will write the attributes directly without

--- a/lib/oj_serializers/serializer.rb
+++ b/lib/oj_serializers/serializer.rb
@@ -261,8 +261,14 @@ protected
 
     # Public: Specify which attributes are going to be obtained by calling a
     # method in the object.
-    def attributes(*method_names, **options)
-      add_attributes(method_names, **options, attribute: :method)
+    def attributes(*method_names, **methods_with_options)
+      attr_options = methods_with_options.extract!(:if, :as)
+      add_attributes(method_names, **attr_options, attribute: :method)
+
+      methods_with_options.each do |name, options|
+        options = {as: options} if options.is_a?(Symbol)
+        add_attribute(name, options)
+      end
     end
     alias_method :attribute, :attributes
 
@@ -277,17 +283,18 @@ protected
     # Syntax Sugar: Allows to use it before a method name.
     #
     # Example:
-    #   serialize
+    #   attribute
     #   def full_name
     #     "#{ first_name } #{ last_name }"
     #   end
-    def serialize(name = nil, **options)
+    def attribute(name = nil, **options)
       if name
         serializer_attributes(name, **options)
       else
         @_current_attribute = options
       end
     end
+    alias_method :attr, :attribute
 
     # Internal: Intercept a method definition, tying a type that was
     # previously specified to the name of the attribute.

--- a/lib/oj_serializers/serializer.rb
+++ b/lib/oj_serializers/serializer.rb
@@ -385,9 +385,10 @@ protected
     #   def full_name
     #     "#{ first_name } #{ last_name }"
     #   end
-    def attribute(name = nil, **options)
+    def attribute(name = nil, **options, &block)
       options[:attribute] = :serializer
       if name
+        define_method(name, &block) if block
         add_attribute(name, options)
       else
         @_current_attribute_options = options

--- a/lib/oj_serializers/version.rb
+++ b/lib/oj_serializers/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OjSerializers
-  VERSION = '2.0.0-beta.1'
+  VERSION = '2.0.0'
 end

--- a/lib/oj_serializers/version.rb
+++ b/lib/oj_serializers/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OjSerializers
-  VERSION = '1.0.2'
+  VERSION = '2.0.0-beta.1'
 end

--- a/oj_serializers.gemspec
+++ b/oj_serializers.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'active_model_serializers', '~> 0.8'
   spec.add_development_dependency 'activerecord'
   spec.add_development_dependency 'benchmark-ips'
+  spec.add_development_dependency 'blueprinter', '~> 0.8'
   spec.add_development_dependency 'memory_profiler'
   spec.add_development_dependency 'mongoid'
   spec.add_development_dependency 'pry-byebug', '~> 3.9'

--- a/oj_serializers.gemspec
+++ b/oj_serializers.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description   = 'oj_serializers leverages the performance of the oj JSON serialization library, and minimizes object allocations, all while provding a similar API to Active Model Serializers.'
   spec.homepage      = 'https://github.com/ElMassimo/oj_serializers'
   spec.license       = 'MIT'
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.3.0')
+  spec.required_ruby_version = Gem::Requirement.new('>= 2.7.0')
 
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = 'https://github.com/ElMassimo/oj_serializers'
@@ -22,22 +22,7 @@ Gem::Specification.new do |spec|
   spec.files         = Dir.glob('{lib}/**/*.rb') + %w[README.md CHANGELOG.md]
   spec.require_paths = ['lib']
 
-  rails_versions = '>= 4.0'
-
   spec.add_dependency 'oj', '>= 3.14.0'
 
-  spec.add_development_dependency 'actionpack', rails_versions
-  spec.add_development_dependency 'active_model_serializers', '~> 0.8'
-  spec.add_development_dependency 'activerecord'
-  spec.add_development_dependency 'benchmark-ips'
-  spec.add_development_dependency 'benchmark-memory'
-  spec.add_development_dependency 'blueprinter', '~> 0.8'
-  spec.add_development_dependency 'memory_profiler'
-  spec.add_development_dependency 'mongoid'
-  spec.add_development_dependency 'pry-byebug', '~> 3.9'
-  spec.add_development_dependency 'railties', rails_versions
-  spec.add_development_dependency 'rake', '~> 13.0'
-  spec.add_development_dependency 'rspec-rails', '~> 4.0'
-  spec.add_development_dependency 'simplecov', '< 0.18'
-  spec.add_development_dependency 'sqlite3'
+  spec.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/oj_serializers.gemspec
+++ b/oj_serializers.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'active_model_serializers', '~> 0.8'
   spec.add_development_dependency 'activerecord'
   spec.add_development_dependency 'benchmark-ips'
+  spec.add_development_dependency 'benchmark-memory'
   spec.add_development_dependency 'blueprinter', '~> 0.8'
   spec.add_development_dependency 'memory_profiler'
   spec.add_development_dependency 'mongoid'

--- a/spec/benchmark_helper.rb
+++ b/spec/benchmark_helper.rb
@@ -13,3 +13,6 @@ require 'active_support/json'
 require 'oj_serializers/compat'
 
 Dir[Pathname.new(__dir__).join('support/**/*.rb')].sort.each { |f| require f }
+
+require 'singed'
+Singed.output_directory = "benchmarks/flamegraphs"

--- a/spec/benchmark_helper.rb
+++ b/spec/benchmark_helper.rb
@@ -15,4 +15,4 @@ require 'oj_serializers/compat'
 Dir[Pathname.new(__dir__).join('support/**/*.rb')].sort.each { |f| require f }
 
 require 'singed'
-Singed.output_directory = "benchmarks/flamegraphs"
+Singed.output_directory = 'benchmarks/flamegraphs'

--- a/spec/benchmark_helper.rb
+++ b/spec/benchmark_helper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-ENV["BENCHMARK"] = "true"
+ENV['BENCHMARK'] = 'true'
 
 require 'spec_helper'
 require 'benchmark/ips'

--- a/spec/benchmark_helper.rb
+++ b/spec/benchmark_helper.rb
@@ -11,9 +11,5 @@ require 'memory_profiler'
 require 'rails'
 require 'active_support/json'
 require 'oj_serializers/compat'
-require 'support/models/album'
-require 'support/serializers/active_model_serializer'
-require 'support/serializers/album_serializer'
-require 'support/serializers/blueprints'
-require 'support/serializers/legacy_serializers'
-require 'support/serializers/option_serializer'
+
+Dir[Pathname.new(__dir__).join('support/**/*.rb')].sort.each { |f| require f }

--- a/spec/benchmark_helper.rb
+++ b/spec/benchmark_helper.rb
@@ -1,8 +1,18 @@
 # frozen_string_literal: true
 
-ENV['BENCHMARK'] ||= 'true'
-
 require 'spec_helper'
 require 'benchmark/ips'
 require 'benchmark'
 require 'memory_profiler'
+
+if ENV['BENCHMARK']
+  require 'rails'
+  require 'active_support/json'
+  require 'oj_serializers/compat'
+  require 'support/models/album'
+  require 'support/serializers/active_model_serializer'
+  require 'support/serializers/album_serializer'
+  require 'support/serializers/blueprints'
+  require 'support/serializers/legacy_serializers'
+  require 'support/serializers/option_serializer'
+end

--- a/spec/benchmark_helper.rb
+++ b/spec/benchmark_helper.rb
@@ -1,18 +1,19 @@
 # frozen_string_literal: true
 
+ENV["BENCHMARK"] = "true"
+
 require 'spec_helper'
 require 'benchmark/ips'
+require 'benchmark/memory'
 require 'benchmark'
 require 'memory_profiler'
 
-if ENV['BENCHMARK']
-  require 'rails'
-  require 'active_support/json'
-  require 'oj_serializers/compat'
-  require 'support/models/album'
-  require 'support/serializers/active_model_serializer'
-  require 'support/serializers/album_serializer'
-  require 'support/serializers/blueprints'
-  require 'support/serializers/legacy_serializers'
-  require 'support/serializers/option_serializer'
-end
+require 'rails'
+require 'active_support/json'
+require 'oj_serializers/compat'
+require 'support/models/album'
+require 'support/serializers/active_model_serializer'
+require 'support/serializers/album_serializer'
+require 'support/serializers/blueprints'
+require 'support/serializers/legacy_serializers'
+require 'support/serializers/option_serializer'

--- a/spec/oj_serializers/associations_spec.rb
+++ b/spec/oj_serializers/associations_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe 'Associations', type: :serializer do
         { first_name: 'Vadim', last_name: 'Gerasimov', full_name: 'Vadim Gerasimov' },
       ],
     }
+    puts GameSerializer.send(:render_as_hash_body)
     expect_parsed_json(GameSerializer.one(game)).to eq attrs
     expect_parsed_json(GameSerializer.many(games)).to eq [attrs, attrs]
   end

--- a/spec/oj_serializers/associations_spec.rb
+++ b/spec/oj_serializers/associations_spec.rb
@@ -18,7 +18,6 @@ RSpec.describe 'Associations', type: :serializer do
         { first_name: 'Vadim', last_name: 'Gerasimov', full_name: 'Vadim Gerasimov' },
       ],
     }
-    puts GameSerializer.send(:render_as_hash_body)
     expect_parsed_json(GameSerializer.one(game)).to eq attrs
     expect_parsed_json(GameSerializer.many(games)).to eq [attrs, attrs]
   end

--- a/spec/oj_serializers/caching_spec.rb
+++ b/spec/oj_serializers/caching_spec.rb
@@ -4,20 +4,20 @@ require 'spec_helper'
 require 'support/models/album'
 require 'support/serializers/album_serializer'
 
+class CachedSongSerializer < SongSerializer
+  # cached
+end
+
+class CachedAlbumSerializer < AlbumSerializer
+  # cached_with_key ->(album) { [album.name] }
+
+  has_many :songs, serializer: CachedSongSerializer
+end
+
 RSpec.xdescribe 'Caching', type: :serializer do
   let!(:album) { Album.abraxas }
   let!(:other_album) { Album.new(name: 'Amigos', release_date: Date.new(1976, 3, 26)) }
   let!(:albums) { [album, other_album] }
-
-  class CachedSongSerializer < SongSerializer
-    # cached
-  end
-
-  class CachedAlbumSerializer < AlbumSerializer
-    # cached_with_key ->(album) { [album.name] }
-
-    has_many :songs, serializer: CachedSongSerializer
-  end
 
   it 'should reuse the cache effectively' do
     attrs = parse_json(AlbumSerializer.one(album))

--- a/spec/oj_serializers/caching_spec.rb
+++ b/spec/oj_serializers/caching_spec.rb
@@ -5,26 +5,37 @@ require 'support/models/album'
 require 'support/serializers/album_serializer'
 
 class CachedSongSerializer < SongSerializer
-  # cached
+  cached
 end
 
 class CachedAlbumSerializer < AlbumSerializer
-  # cached_with_key ->(album) { [album.name] }
+  cached_with_key ->(album) { [album.name] }
 
   has_many :songs, serializer: CachedSongSerializer
 end
 
-RSpec.xdescribe 'Caching', type: :serializer do
+RSpec.describe 'Caching', type: :serializer do
   let!(:album) { Album.abraxas }
-  let!(:other_album) { Album.new(name: 'Amigos', release_date: Date.new(1976, 3, 26)) }
+  let!(:other_album) { Album.new(id: 1, name: 'Amigos', release_date: Date.new(1976, 3, 26)) }
   let!(:albums) { [album, other_album] }
 
+  before do
+    # NOTE: Uncomment to debug test failures.
+    # Oj::Serializer::CACHE.logger = ActiveSupport::Logger.new(STDOUT)
+  end
+
   it 'should reuse the cache effectively' do
+    allow_any_instance_of(Mongoid::Document).to receive(:new_record?).and_return(false)
+
     attrs = parse_json(AlbumSerializer.one(album))
     expect(attrs).to include(name: album.name)
     other_attrs = parse_json(AlbumSerializer.one(other_album))
-    expect(other_attrs).to eq(name: 'Amigos', release: 'March 26, 1976', genres: nil, songs: [])
+    expect(other_attrs).to eq(id: 1, name: 'Amigos', release: 'March 26, 1976', genres: nil, songs: [])
 
+    expect(album.songs.first).to receive(:composer).once.and_call_original
+    expect_parsed_json(CachedSongSerializer.many(album.songs)).to eq attrs[:songs]
+
+    expect(album.songs.first).not_to receive(:composer)
     expect(album).to receive(:release_date).once.and_call_original
     expect(other_album).to receive(:release_date).once.and_call_original
     expect_parsed_json(CachedAlbumSerializer.one(album)).to eq attrs
@@ -34,5 +45,22 @@ RSpec.xdescribe 'Caching', type: :serializer do
     expect_parsed_json(CachedAlbumSerializer.one(album)).to eq attrs
     expect_parsed_json(CachedAlbumSerializer.one(other_album)).to eq other_attrs
     expect_parsed_json(CachedAlbumSerializer.many(albums)).to eq [attrs, other_attrs]
+  end
+
+  it 'should reuse the cache effectively for JSON' do
+    attrs = parse_json(AlbumSerializer.one_as_json(album))
+    expect(attrs).to include(name: album.name)
+    other_attrs = parse_json(AlbumSerializer.one_as_json(other_album))
+    expect(other_attrs).to eq(name: 'Amigos', release: 'March 26, 1976', genres: nil, songs: [])
+
+    expect(album).to receive(:release_date).once.and_call_original
+    expect(other_album).to receive(:release_date).once.and_call_original
+    expect_parsed_json(CachedAlbumSerializer.one_as_json(album)).to eq attrs
+    expect_parsed_json(CachedAlbumSerializer.one_as_json(other_album)).to eq other_attrs
+
+    expect_any_instance_of(Album).not_to receive(:release_date)
+    expect_parsed_json(CachedAlbumSerializer.one_as_json(album)).to eq attrs
+    expect_parsed_json(CachedAlbumSerializer.one_as_json(other_album)).to eq other_attrs
+    expect_parsed_json(CachedAlbumSerializer.many_as_json(albums)).to eq [attrs, other_attrs]
   end
 end

--- a/spec/oj_serializers/caching_spec.rb
+++ b/spec/oj_serializers/caching_spec.rb
@@ -4,20 +4,20 @@ require 'spec_helper'
 require 'support/models/album'
 require 'support/serializers/album_serializer'
 
-class CachedSongSerializer < SongSerializer
-  cached
-end
-
-class CachedAlbumSerializer < AlbumSerializer
-  cached_with_key ->(album) { [album.name] }
-
-  has_many :songs, serializer: CachedSongSerializer
-end
-
-RSpec.describe 'Caching', type: :serializer do
+RSpec.xdescribe 'Caching', type: :serializer do
   let!(:album) { Album.abraxas }
   let!(:other_album) { Album.new(name: 'Amigos', release_date: Date.new(1976, 3, 26)) }
   let!(:albums) { [album, other_album] }
+
+  class CachedSongSerializer < SongSerializer
+    # cached
+  end
+
+  class CachedAlbumSerializer < AlbumSerializer
+    # cached_with_key ->(album) { [album.name] }
+
+    has_many :songs, serializer: CachedSongSerializer
+  end
 
   it 'should reuse the cache effectively' do
     attrs = parse_json(AlbumSerializer.one(album))

--- a/spec/oj_serializers/dev_mode_spec.rb
+++ b/spec/oj_serializers/dev_mode_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Development Mode', type: :serializer do
 
   it 'should fail early when memoization is used incorrectly' do
     expect { StatefulSerializer.many([album, album]) }
-      .to raise_error(ArgumentError, 'Serializer instances are reused so they must be stateless. Use `memo.fetch` for memoization purposes instead. Bad keys: name')
+      .to raise_error(ArgumentError, 'Serializer instances are reused so they must be stateless. Use `memo.fetch` for memoization purposes instead. Bad keys: name in StatefulSerializer')
   end
 
   it 'should fail early when `attributes` is used instead of `serializer_attributes`' do

--- a/spec/oj_serializers/dev_mode_spec.rb
+++ b/spec/oj_serializers/dev_mode_spec.rb
@@ -7,7 +7,7 @@ require 'support/serializers/invalid_album_serializer'
 class StatefulSerializer < Oj::Serializer
   hash_attributes 'genre'
 
-  serialize
+  attribute
   def name
     @name ||= @object.name
   end

--- a/spec/oj_serializers/dev_mode_spec.rb
+++ b/spec/oj_serializers/dev_mode_spec.rb
@@ -7,7 +7,7 @@ require 'support/serializers/invalid_album_serializer'
 class StatefulSerializer < Oj::Serializer
   hash_attributes 'genre'
 
-  attribute \
+  serialize
   def name
     @name ||= @object.name
   end

--- a/spec/oj_serializers/dev_mode_spec.rb
+++ b/spec/oj_serializers/dev_mode_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe 'Development Mode', type: :serializer do
       .to raise_error(NoMethodError, /Perhaps you meant to call "release" in InvalidAlbumSerializer instead?/)
   end
 
-  it 'should fail early when there is a typo or missing field in Mongoid' do
+  xit 'should fail early when there is a typo or missing field in Mongoid' do
     expect { MissingAttributeSerializer.one_if(album) }
       .to raise_error(ActiveModel::MissingAttributeError, /Missing attribute: 'name2'/)
   end

--- a/spec/oj_serializers/json_string_encoder_spec.rb
+++ b/spec/oj_serializers/json_string_encoder_spec.rb
@@ -63,77 +63,77 @@ RSpec.describe OjSerializers::JsonStringEncoder, type: :serializer do
     let(:album) { Album.abraxas }
     let(:album_hash) do
       {
-        "name": 'Abraxas',
-        "genres": [
+        name: 'Abraxas',
+        genres: [
           'Pyschodelic Rock',
           'Blues Rock',
           'Jazz Fusion',
           'Latin Rock',
         ],
-        "release": 'September 23, 1970',
-        "songs": [
+        release: 'September 23, 1970',
+        songs: [
           {
-            "track": 1,
-            "name": 'Sing Winds, Crying Beasts',
-            "composers": [
+            track: 1,
+            name: 'Sing Winds, Crying Beasts',
+            composers: [
               'Michael Carabello',
             ],
           },
           {
-            "track": 2,
-            "name": 'Black Magic Woman / Gypsy Queen',
-            "composers": [
+            track: 2,
+            name: 'Black Magic Woman / Gypsy Queen',
+            composers: [
               'Peter Green',
               'Gábor Szabó',
             ],
           },
           {
-            "track": 3,
-            "name": 'Oye como va',
-            "composers": [
+            track: 3,
+            name: 'Oye como va',
+            composers: [
               'Tito Puente',
             ],
           },
           {
-            "track": 4,
-            "name": 'Incident at Neshabur',
-            "composers": [
+            track: 4,
+            name: 'Incident at Neshabur',
+            composers: [
               'Alberto Gianquinto',
               'Carlos Santana',
             ],
           },
           {
-            "track": 5,
-            "name": 'Se acabó',
-            "composers": [
+            track: 5,
+            name: 'Se acabó',
+            composers: [
               'José Areas',
             ],
           },
           {
-            "track": 6,
-            "name": "Mother's Daughter",
-            "composers": [
+            track: 6,
+            name: "Mother's Daughter",
+            composers: [
               'Gregg Rolie',
             ],
           },
           {
-            "track": 7,
-            "name": 'Samba pa ti',
-            "composers": [
+            track: 7,
+            name: 'Samba pa ti',
+            composers: [
               'Santana',
             ],
           },
           {
-            "track": 8,
-            "name": "Hope You're Feeling Better",
-            "composers": [
+            track: 8,
+            name: "Hope You're Feeling Better",
+            composers: [
               'Rolie',
             ],
           },
           {
-            "track": 9,
-            "name": 'El Nicoya',
-            "composers": [
+            track: 9,
+            name: 'El Nicoya',
+            composers: [
               'Areas',
             ],
           },

--- a/spec/oj_serializers/sugar_spec.rb
+++ b/spec/oj_serializers/sugar_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe AlbumsController, type: :controller do
     Rails.application.quick_setup
   end
 
-  it 'should be able to use serializer options and legacy serializers' do
+  it 'should use serializer options' do
     get :list
     albums = parse_json[:albums]
     expect(albums.size).to eq 3
@@ -32,7 +32,9 @@ RSpec.describe AlbumsController, type: :controller do
       name: 'Black Magic Woman / Gypsy Queen',
       composers: ['Peter Green', 'Gábor Szabó'],
     )
+  end
 
+  it 'should be able to render legacy serializers' do
     get :legacy_list
     legacy_albums = parse_json[:albums]
     expect(legacy_albums.map { |a| a.except(:special) }).to eq albums

--- a/spec/oj_serializers/sugar_spec.rb
+++ b/spec/oj_serializers/sugar_spec.rb
@@ -32,9 +32,7 @@ RSpec.describe AlbumsController, type: :controller do
       name: 'Black Magic Woman / Gypsy Queen',
       composers: ['Peter Green', 'Gábor Szabó'],
     )
-  end
 
-  it 'should be able to render legacy serializers' do
     get :legacy_list
     legacy_albums = parse_json[:albums]
     expect(legacy_albums.map { |a| a.except(:special) }).to eq albums

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,8 @@ end
 
 module JsonHelpers
   def parse_json(json = response.body)
+    return json if json.is_a?(Array) || json.is_a?(Hash)
+
     item = JSON.parse(json)
     item.is_a?(Array) ? item.map(&:deep_symbolize_keys) : item.deep_symbolize_keys!
   end
@@ -43,4 +45,8 @@ RSpec.configure do |config|
   end
 
   config.include JsonHelpers
+
+  config.before(benchmark: true) do
+    raise ArgumentError, "Please run it with BENCHMARK='true'" unless ENV['BENCHMARK']
+  end
 end

--- a/spec/support/models/sql.rb
+++ b/spec/support/models/sql.rb
@@ -57,7 +57,7 @@ class Player < ActiveRecord::Base
 end
 
 class PlayerSerializer < Oj::Serializer
-  attributes :id, if: -> { player.persisted? }
+  identifier
   attributes :first_name, :last_name, :full_name
 end
 
@@ -68,7 +68,7 @@ class ScoresSerializer < Oj::Serializer
 end
 
 class GameSerializer < Oj::Serializer
-  attributes :id, if: -> { game.persisted? }
+  identifier
   attributes :name
 
   flat_one :game, serializer: ScoresSerializer

--- a/spec/support/serializers/alba.rb
+++ b/spec/support/serializers/alba.rb
@@ -38,7 +38,7 @@ class AlbumAlba < BaseAlba
   end
 
   attributes :special, if: proc { params[:special] }
-  def special(album)
+  def special(_album)
     params[:special]
   end
 

--- a/spec/support/serializers/alba.rb
+++ b/spec/support/serializers/alba.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'alba'
+
+Alba.backend = :oj_rails
+Alba.inflector = :active_support
+
+class BaseAlba
+  include Alba::Resource
+  transform_keys :lower_camel
+end
+
+class SongAlba < BaseAlba
+  attributes :id, if: proc { |song| !song.new_record? }
+
+  attributes(
+    :track,
+    :name,
+    :composers,
+  )
+
+  def composers(song)
+    song.composer&.split(', ')
+  end
+end
+
+class AlbumAlba < BaseAlba
+  attributes :id, if: proc { |album| !album.new_record? }
+
+  attributes(
+    :name,
+    :genres,
+  )
+
+  attributes :release, if: proc { |album| album.released? }
+  def release(album)
+    album.release_date.strftime('%B %d, %Y')
+  end
+
+  attributes :special, if: proc { params[:special] }
+  def special(album)
+    params[:special]
+  end
+
+  many :songs, resource: SongAlba
+  many :other_songs, resource: SongAlba, if: proc { |album| album.other_songs.present? }
+end
+
+class ModelAlba < BaseAlba
+  attributes(
+    :id,
+    :name,
+  )
+end

--- a/spec/support/serializers/album_serializer.rb
+++ b/spec/support/serializers/album_serializer.rb
@@ -3,28 +3,26 @@
 require_relative 'song_serializer'
 
 class AlbumSerializer < Oj::Serializer
+  identifier
+
   mongo_attributes(
     :id,
     :name,
     :genres,
   )
 
-  has_many :songs, serializer: SongSerializer
-  has_many :other_songs, serializer: SongSerializer, if: -> { other_songs.present? }
-
-  attribute \
+  serialize if: -> { album.released? }
   def release
     album.release_date.strftime('%B %d, %Y')
-  end, if: -> { album.released? }
+  end
 
-  attribute \
-  def special
-    special?
-  end, if: -> { special? }
-
+  serialize if: -> { special? }, as: :specials
   def special?
     memo.fetch(:special) { options[:special] }
   end
+
+  has_many :songs, serializer: SongSerializer
+  has_many :other_songs, serializer: SongSerializer, if: -> { other_songs.present? }
 
   def other_songs
     []

--- a/spec/support/serializers/album_serializer.rb
+++ b/spec/support/serializers/album_serializer.rb
@@ -3,7 +3,7 @@
 require_relative 'song_serializer'
 
 class AlbumSerializer < Oj::Serializer
-  identifier
+  transform_keys :camelize
 
   mongo_attributes(
     :id,
@@ -16,7 +16,7 @@ class AlbumSerializer < Oj::Serializer
     album.release_date.strftime('%B %d, %Y')
   end
 
-  serialize if: -> { special? }, as: :specials
+  serialize if: -> { special? }, as: :special
   def special?
     memo.fetch(:special) { options[:special] }
   end

--- a/spec/support/serializers/album_serializer.rb
+++ b/spec/support/serializers/album_serializer.rb
@@ -11,12 +11,12 @@ class AlbumSerializer < Oj::Serializer
     :genres,
   )
 
-  serialize if: -> { album.released? }
+  attribute if: -> { album.released? }
   def release
     album.release_date.strftime('%B %d, %Y')
   end
 
-  serialize if: -> { special? }, as: :special
+  attribute if: -> { special? }, as: :special
   def special?
     memo.fetch(:special) { options[:special] }
   end

--- a/spec/support/serializers/blueprints.rb
+++ b/spec/support/serializers/blueprints.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'blueprinter'
+require 'oj_serializers/compat'
+
+Blueprinter.configure do |config|
+  config.sort_fields_by = :definition
+end
+
+class SongBlueprint < Blueprinter::Base
+  field :id, if: ->(_, song, _) { !song.new_record? }
+
+  fields(
+    :track,
+    :name,
+  )
+
+  field :composers do |song|
+    song.composer&.split(', ')
+  end
+end
+
+class AlbumBlueprint < Blueprinter::Base
+  field :id, if: ->(_, album, _) { !album.new_record? }
+
+  fields(
+    :name,
+    :genres,
+  )
+
+  field :release, if: ->(_field_name, album, options) { album.released? } do |album|
+    album.release_date.strftime('%B %d, %Y')
+  end
+
+  field :special, if: ->(_, _, options) { options[:special] } do |_, options|
+    options[:special]
+  end
+
+  association :songs, blueprint: SongBlueprint
+  association :other_songs, blueprint: SongBlueprint, if: ->(_, _, _) { false } do
+    []
+  end
+end
+
+class ModelBlueprint < Blueprinter::Base
+  fields(
+    :id,
+    :name,
+  )
+end

--- a/spec/support/serializers/blueprints.rb
+++ b/spec/support/serializers/blueprints.rb
@@ -28,7 +28,7 @@ class AlbumBlueprint < Blueprinter::Base
     :genres,
   )
 
-  field :release, if: ->(_field_name, album, options) { album.released? } do |album|
+  field :release, if: ->(_field_name, album, _options) { album.released? } do |album|
     album.release_date.strftime('%B %d, %Y')
   end
 

--- a/spec/support/serializers/model_serializer.rb
+++ b/spec/support/serializers/model_serializer.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
 class ModelSerializer < Oj::Serializer
-  # NOTE: ams_attributes is not recommended, it's better to be explicit about
-  # the strategy.
-  ams_attributes(
+  attributes(
     :id,
     :name,
   )

--- a/spec/support/serializers/option_serializer.rb
+++ b/spec/support/serializers/option_serializer.rb
@@ -2,6 +2,7 @@
 
 require 'oj_serializers'
 require 'active_model_serializers'
+require 'blueprinter'
 
 module OptionSerializer
   class AMS < ActiveModel::Serializer
@@ -15,6 +16,16 @@ module OptionSerializer
     end
 
     def value
+      object.attributes['_id']
+    end
+  end
+
+  class Blueprinter < Blueprinter::Base
+    field :label do |object|
+      object.attributes['name']
+    end
+
+    field :value do |object|
       object.attributes['_id']
     end
   end

--- a/spec/support/serializers/option_serializer.rb
+++ b/spec/support/serializers/option_serializer.rb
@@ -45,11 +45,13 @@ module OptionSerializer
   end
 
   class Oj < Oj::Serializer
-    attr def label
+    attr
+    def label
       @object.attributes['name']
     end
 
-    attr def value
+    attr
+    def value
       @object.attributes['_id']
     end
   end

--- a/spec/support/serializers/option_serializer.rb
+++ b/spec/support/serializers/option_serializer.rb
@@ -3,8 +3,22 @@
 require 'oj_serializers'
 require 'active_model_serializers'
 require 'blueprinter'
+require 'panko_serializer'
+require_relative 'alba'
 
 module OptionSerializer
+  class Alba
+    include ::Alba::Resource
+
+    attribute :label do |object|
+      object.attributes['name']
+    end
+
+    attribute :value do |object|
+      object.attributes['_id']
+    end
+  end
+
   class AMS < ActiveModel::Serializer
     attributes(
       :label,
@@ -36,6 +50,18 @@ module OptionSerializer
     end
 
     attr def value
+      @object.attributes['_id']
+    end
+  end
+
+  class Panko < Panko::Serializer
+    attributes(:label, :value)
+
+    def label
+      @object.attributes['name']
+    end
+
+    def value
       @object.attributes['_id']
     end
   end

--- a/spec/support/serializers/option_serializer.rb
+++ b/spec/support/serializers/option_serializer.rb
@@ -31,13 +31,11 @@ module OptionSerializer
   end
 
   class Oj < Oj::Serializer
-    serialize
-    def label
+    attr def label
       @object.attributes['name']
     end
 
-    serialize
-    def value
+    attr def value
       @object.attributes['_id']
     end
   end

--- a/spec/support/serializers/option_serializer.rb
+++ b/spec/support/serializers/option_serializer.rb
@@ -31,12 +31,12 @@ module OptionSerializer
   end
 
   class Oj < Oj::Serializer
-    attribute \
+    serialize
     def label
       @object.attributes['name']
     end
 
-    attribute \
+    serialize
     def value
       @object.attributes['_id']
     end

--- a/spec/support/serializers/panko.rb
+++ b/spec/support/serializers/panko.rb
@@ -2,16 +2,15 @@
 
 require 'panko_serializer'
 
-Mongoid::Criteria.prepend Module.new {
-  def track
-  end
-}
+Mongoid::Criteria.prepend(Module.new {
+  def track; end
+})
 
-Album.prepend Module.new {
+Album.prepend(Module.new {
   def other_songs
     []
   end
-}
+})
 
 class SongPanko < Panko::Serializer
   attributes(
@@ -30,9 +29,9 @@ class SongPanko < Panko::Serializer
   end
 
   # NOTE: Panko does not have a way to conditionally not include an attribute.
-  def self.filters_for(context, scope)
+  def self.filters_for(_context, _scope)
     {
-      except: [:id]
+      except: [:id],
     }
   end
 end
@@ -47,7 +46,7 @@ class AlbumPanko < Panko::Serializer
     :name,
     :genres,
     :release,
-    :special
+    :special,
   )
 
   def release
@@ -66,9 +65,9 @@ class AlbumPanko < Panko::Serializer
   end
 
   # NOTE: Panko does not have a way to conditionally not include an attribute.
-  def self.filters_for(context, scope)
+  def self.filters_for(_context, _scope)
     {
-      except: [:id, :other_songs]
+      except: %i[id other_songs],
     }
   end
 end

--- a/spec/support/serializers/panko.rb
+++ b/spec/support/serializers/panko.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'panko_serializer'
+
+Mongoid::Criteria.prepend Module.new {
+  def track
+  end
+}
+
+Album.prepend Module.new {
+  def other_songs
+    []
+  end
+}
+
+class SongPanko < Panko::Serializer
+  attributes(
+    :id,
+    :track,
+    :name,
+    :composers,
+  )
+
+  def id
+    object.id unless object.new_record?
+  end
+
+  def composers
+    object.composer&.split(', ')
+  end
+
+  # NOTE: Panko does not have a way to conditionally not include an attribute.
+  def self.filters_for(context, scope)
+    {
+      except: [:id]
+    }
+  end
+end
+
+class AlbumPanko < Panko::Serializer
+  attributes
+  def id
+    object.id unless object.new_record?
+  end
+
+  attributes(
+    :name,
+    :genres,
+    :release,
+    :special
+  )
+
+  def release
+    object.release_date.strftime('%B %d, %Y') if object.released?
+  end
+
+  def special
+    context[:special] if context
+  end
+
+  has_many :songs, serializer: SongPanko
+  has_many :other_songs, serializer: SongPanko
+
+  def other_songs
+    other_songs if other_songs.present?
+  end
+
+  # NOTE: Panko does not have a way to conditionally not include an attribute.
+  def self.filters_for(context, scope)
+    {
+      except: [:id, :other_songs]
+    }
+  end
+end
+
+class ModelPanko < Panko::Serializer
+  attributes(
+    :id,
+    :name,
+  )
+end

--- a/spec/support/serializers/song_serializer.rb
+++ b/spec/support/serializers/song_serializer.rb
@@ -10,7 +10,7 @@ class SongSerializer < Oj::Serializer
     :name,
   )
 
-  attribute \
+  serialize
   def composers
     song.composer&.split(', ')
   end

--- a/spec/support/serializers/song_serializer.rb
+++ b/spec/support/serializers/song_serializer.rb
@@ -10,7 +10,7 @@ class SongSerializer < Oj::Serializer
     :name,
   )
 
-  serialize
+  attribute
   def composers
     song.composer&.split(', ')
   end

--- a/spec/support/serializers/song_serializer.rb
+++ b/spec/support/serializers/song_serializer.rb
@@ -10,10 +10,7 @@ class SongSerializer < Oj::Serializer
     :name,
   )
 
-  serializer_attributes(
-    :composers,
-  )
-
+  attribute \
   def composers
     song.composer&.split(', ')
   end


### PR DESCRIPTION
### Description 📖 

This pull request introduces a rework of the internals, after experimenting with ways to reduce the indirection to obtain the values for each attribute.

It has more features than v1, while increasing performance even further 🚀 

### Features ✨ 

- Added `render_as_hash` to efficiently build a Hash from the serializer
- `render` shortcut, unifying `one` and `many`
- `transform_keys :camelize`: a built-in setting to convert keys, in a way that does not affect runtime performance
- `sort_keys_by :name`: allows to sort the response alphabetically, without affecting runtime performance
- `serialize` as an easier approach to define serializer attributes

### Breaking Changes

Since returning a `Hash` is more convenient than returning a `Oj::StringWriter`, and performance is comparable, I'm considering making `default_format :hash` the default.

The previous APIs will still be available as `one_as_json` and `many_as_json`, as well as a `default_format :json` setting to make the library work exactly the same as in version 1.

### Performance 🚀 

Additional optimizations have made JSON rendering  __20% to 40% faster__ than the previous version, so it's now __3x to 7x faster__ than `active_model_serializers` or `blueprinter`.

These are some preliminary results from running the [benchmarks](https://github.com/ElMassimo/oj_serializers/blob/perf/render-in-hash/benchmarks/album_serializer_benchmark.rb) running on a MacBook Pro (16-inch, 2021, M1 Pro):

#### serializing options

```
        oj_serializers (v2):     9257.4 i/s
   oj_serializers (v2 hash):     9256.2 i/s
                      panko:     8902.1 i/s - 1.20x slower
        oj_serializers (v1):     6579.9 i/s - 1.40x slower
                       alba:     2330.7 i/s - 4.58x slower
                blueprinter:     1741.4 i/s - 5.32x slower
   active_model_serializers:     1308.1 i/s - 7.08x slower
```

#### serializing a model

```
   oj_serializers (v2 hash):    23819.3 i/s
        oj_serializers (v2):    22655.6 i/s - 1.05x slower
        oj_serializers (v1):    19870.2 i/s - 1.20x slower
                      panko:    13756.3 i/s - 1.72x slower
                blueprinter:     6635.5 i/s - 3.59x slower
   active_model_serializers:     6298.1 i/s - 3.78x slower
                       alba:     4197.5 i/s - 5.64x slower
```

#### serializing a collection

```
     oj_serializers as_hash:      243.6 i/s
             oj_serializers:      239.4 i/s - 1.02x slower
                      panko:      169.8 i/s - 1.43x slower
                blueprinter:       68.5 i/s - 3.56x slower
   active_model_serializers:       64.3 i/s - 3.79x slower
                       alba:       44.7 i/s - 5.44x slower
```

#### serializing a large collection

```
             oj_serializers:       23.1 i/s
     oj_serializers as_hash:       23.1 i/s - 1.00x slower
                      panko:       16.6 i/s - 1.40x slower
                blueprinter:        6.6 i/s - 3.53x slower
   active_model_serializers:        6.1 i/s - 3.79x slower
                       alba:        4.1 i/s - 5.64x slower
```

#### memory when serializing an object

```
                         oj:       5809 allocated
                    oj_hash:       6809 allocated - 1.17x more
                blueprinter:      17465 allocated - 3.01x more
                        ams:      26704 allocated - 4.60x more
```

#### memory when serializing a collection

```
                         oj:    5521290 allocated
                    oj_hash:    6777082 allocated - 1.23x more
                blueprinter:   17217298 allocated - 3.12x more
                        ams:   26672082 allocated - 4.83x more
```