### PR TITLE
fix: allow using active_model_serializers in associations (compat)

### DIFF
--- a/lib/oj_serializers/compat.rb
+++ b/lib/oj_serializers/compat.rb
@@ -46,7 +46,21 @@ class ActiveModel::Serializer
     end
     writer.pop
   end
+
+  module OjOptionsCompat
+    def add_attribute(value_from, key: nil, **options)
+      options[:as] ||= key if key
+
+      if (unless_proc = options.delete(:unless))
+        options[:if] = -> { !instance_exec(&unless_proc) }
+      end
+
+      super(value_from, **options)
+    end
+  end
 end
 
 require 'oj_serializers'
 require 'oj_serializers/sugar'
+
+Oj::Serializer.singleton_class.prepend(ActiveModel::Serializer::OjOptionsCompat)

--- a/lib/oj_serializers/compat.rb
+++ b/lib/oj_serializers/compat.rb
@@ -14,6 +14,38 @@ class ActiveModel::Serializer
   def self.many(array, options = nil)
     array.map { |object| new(object, options) }
   end
+
+  # OjSerializer: Used internally to write a single object association in :hash mode.
+  #
+  # Returns nothing.
+  def self.one_as_hash(object)
+    new(object)
+  end
+
+  # OjSerializer: Used internally to write an association in :hash mode.
+  #
+  # Returns nothing.
+  def self.many_as_hash(array)
+    array.map { |object| new(object) }
+  end
+
+  # OjSerializer: Used internally to write a single object association in :json mode.
+  #
+  # Returns nothing.
+  def self.write_one(writer, object, options)
+    writer.push_value(new(object, options))
+  end
+
+  # OjSerializer: Used internally to write an association in :json mode.
+  #
+  # Returns nothing.
+  def self.write_many(writer, array, options)
+    writer.push_array
+    array.each do |object|
+      write_one(writer, object, options)
+    end
+    writer.pop
+  end
 end
 
 require 'oj_serializers'

--- a/lib/oj_serializers/compat.rb
+++ b/lib/oj_serializers/compat.rb
@@ -32,17 +32,17 @@ class ActiveModel::Serializer
   # OjSerializer: Used internally to write a single object association in :json mode.
   #
   # Returns nothing.
-  def self.write_one(writer, object, options)
-    writer.push_value(new(object, options))
+  def self.write_one(writer, object)
+    writer.push_value(new(object))
   end
 
   # OjSerializer: Used internally to write an association in :json mode.
   #
   # Returns nothing.
-  def self.write_many(writer, array, options)
+  def self.write_many(writer, array)
     writer.push_array
     array.each do |object|
-      write_one(writer, object, options)
+      write_one(writer, object)
     end
     writer.pop
   end

--- a/spec/oj_serializers/compat_spec.rb
+++ b/spec/oj_serializers/compat_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+require 'support/models/album'
+require 'support/serializers/active_model_serializer'
+
+class CompatSerializer < Oj::Serializer
+  has_one :item, serializer: ActiveModelSerializer
+  has_many :items, serializer: ActiveModelSerializer
+end
+
+RSpec.describe "AMS Compat", type: :serializer do
+  def expect_encoded_json(object)
+    expect(Oj.dump(object).tr("\n", ''))
+  end
+
+  it 'can use ams serializer in associations' do
+    album = Album.abraxas.tap { |a| a.id = 1 }
+    object = OpenStruct.new(item: album, items: [album, album])
+    attrs = {id: 1, name: "Abraxas"}
+
+    expect_encoded_json(CompatSerializer.one(object)).to eq({
+      item: attrs,
+      items: [attrs, attrs],
+    }.to_json)
+  end
+end

--- a/spec/oj_serializers/compat_spec.rb
+++ b/spec/oj_serializers/compat_spec.rb
@@ -6,8 +6,8 @@ require 'support/models/album'
 require 'support/serializers/active_model_serializer'
 
 class CompatSerializer < Oj::Serializer
-  has_one :item, serializer: ActiveModelSerializer
-  has_many :items, serializer: ActiveModelSerializer
+  has_one :item, key: :album, serializer: ActiveModelSerializer
+  has_many :items, serializer: ActiveModelSerializer, unless: -> { options[:skip_collection] }
 end
 
 class JsonCompatSerializer < CompatSerializer
@@ -25,13 +25,21 @@ RSpec.describe 'AMS Compat', type: :serializer do
     attrs = { id: 1, name: 'Abraxas' }
 
     expect_encoded_json(CompatSerializer.one(object)).to eq({
-      item: attrs,
+      album: attrs,
       items: [attrs, attrs],
     }.to_json)
 
+    expect_encoded_json(CompatSerializer.one(object, skip_collection: true)).to eq({
+      album: attrs,
+    }.to_json)
+
     expect_encoded_json(JsonCompatSerializer.one(object)).to eq({
-      item: attrs,
+      album: attrs,
       items: [attrs, attrs],
+    }.to_json)
+
+    expect_encoded_json(JsonCompatSerializer.one(object, skip_collection: true)).to eq({
+      album: attrs,
     }.to_json)
   end
 end

--- a/spec/oj_serializers/compat_spec.rb
+++ b/spec/oj_serializers/compat_spec.rb
@@ -14,15 +14,15 @@ class JsonCompatSerializer < CompatSerializer
   default_format :json
 end
 
-RSpec.describe "AMS Compat", type: :serializer do
+RSpec.describe 'AMS Compat', type: :serializer do
   def expect_encoded_json(object)
     expect(Oj.dump(object).tr("\n", ''))
   end
 
   it 'can use ams serializer in associations' do
     album = Album.abraxas.tap { |a| a.id = 1 }
-    object = OpenStruct.new(item: album, items: [album, album])
-    attrs = {id: 1, name: "Abraxas"}
+    object = double('compat', item: album, items: [album, album])
+    attrs = { id: 1, name: 'Abraxas' }
 
     expect_encoded_json(CompatSerializer.one(object)).to eq({
       item: attrs,

--- a/spec/oj_serializers/compat_spec.rb
+++ b/spec/oj_serializers/compat_spec.rb
@@ -10,6 +10,10 @@ class CompatSerializer < Oj::Serializer
   has_many :items, serializer: ActiveModelSerializer
 end
 
+class JsonCompatSerializer < CompatSerializer
+  default_format :json
+end
+
 RSpec.describe "AMS Compat", type: :serializer do
   def expect_encoded_json(object)
     expect(Oj.dump(object).tr("\n", ''))
@@ -21,6 +25,11 @@ RSpec.describe "AMS Compat", type: :serializer do
     attrs = {id: 1, name: "Abraxas"}
 
     expect_encoded_json(CompatSerializer.one(object)).to eq({
+      item: attrs,
+      items: [attrs, attrs],
+    }.to_json)
+
+    expect_encoded_json(JsonCompatSerializer.one(object)).to eq({
       item: attrs,
       items: [attrs, attrs],
     }.to_json)


### PR DESCRIPTION
### Description 📖 

This pull request fixes a bug introduced in:
- #9,

which prevented mixing `active_model_serializers` in `oj_serializers` associations, as reported in:

- https://github.com/ElMassimo/oj_serializers/discussions/11

### Background 📜 

Although `JsonStringEncoder` was simplified and `new_json_writer` is no longer necessary, we still need to implement `write_to_one` and `write_to_many`, and now `one_as_hash` and `one_as_many` in order to mix serializers in associations.