### PR TITLE
add configuration and cache options

### DIFF
--- a/lib/oj_serializers.rb
+++ b/lib/oj_serializers.rb
@@ -1,6 +1,17 @@
 # frozen_string_literal: true
 
+module OjSerializers
+  def self.configuration
+    @configuration ||= OjSerializers::Config.new
+  end
+
+  def self.configure
+    yield(configuration)
+  end
+end
+
 require 'oj'
+require 'oj_serializers/config'
 require 'oj_serializers/version'
 require 'oj_serializers/setup'
 require 'oj_serializers/serializer'

--- a/lib/oj_serializers/config.rb
+++ b/lib/oj_serializers/config.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class OjSerializers::Config
+  attr_accessor :cache
+
+  def initialize
+    self.cache = (defined?(Rails) && Rails.cache) ||
+                 (defined?(ActiveSupport::Cache::MemoryStore) ? ActiveSupport::Cache::MemoryStore.new : OjSerializers::Memo.new)
+  end
+end


### PR DESCRIPTION
This PR adds configuration
```ruby
OjSerializers.configure do |config|
  config.cache = SomeCacheModule.new
end
```
and adds cache_options
```ruby
class SomeSerializer < Oj::Serializer
  attributes :id, :name
end

class CachedSomeSerializer < SomeSerializer
  cached(cache_key: ->(object) { object.id }, options: { expires_id: 1.minute, ... }) # args are optional 
  # or
  cached_with_key ->(object) { object.id }
  # or
  cached_with_options expires_in: 1.minute
end
```
PR also has breaking changes 