### PR TITLE
Fix sorting logic of attributes

### DIFF
--- a/lib/oj_serializers/serializer.rb
+++ b/lib/oj_serializers/serializer.rb
@@ -713,7 +713,7 @@ protected
       if sort_by == :name
         sort_by = ->(name, options, _) { options[:identifier] ? "__#{name}" : name }
       elsif !sort_by || sort_by == :definition
-        sort_by = ->(name, options, index) { options[:identifier] ? "__#{name}" : "zzz#{index}" }
+        sort_by = ->(name, options, index) { options[:identifier] ? -1 : index }
       end
 
       attributes.sort_by.with_index { |(name, options), index| sort_by.call(name, options, index) }.to_h


### PR DESCRIPTION
The attributes with index 10+ are sorted after index 1 and before index 2, because sorting incorrectly uses lexical sorting instead of numerical sorting.