### PR TITLE
Fix JsonValue double-encoding on Rails 8.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,10 @@ jobs:
         ]
         experimental: [false]
         include:
+          - ruby: "3.4.5"
+            os: ubuntu-latest
+            gemfile: Gemfile-rails.8.1.x
+            experimental: false
           - ruby: "3.3"
             os: ubuntu-latest
             gemfile: Gemfile-rails.7.2.x

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Fixes 🐞
+
+- Enable `use_raw_json` before `Oj.optimize_rails` so `JsonValue` is not double-encoded on Rails 8.1+.
+
 ## Oj Serializers 3.0.0 (2026-01-02)
 
 ### Features ✨

--- a/gemfiles/Gemfile-rails.8.1.x
+++ b/gemfiles/Gemfile-rails.8.1.x
@@ -1,0 +1,5 @@
+require_relative "base"
+
+eval main_gemfile
+
+gem 'rails', '~> 8.1.0'

--- a/lib/oj_serializers/setup.rb
+++ b/lib/oj_serializers/setup.rb
@@ -4,10 +4,16 @@ require 'oj'
 
 # NOTE: We automatically set the necessary configuration unless it had been
 # explicitly set beforehand.
+#
+# `use_raw_json` must be enabled *before* `Oj.optimize_rails`. Rails 8.1
+# memoizes an option-less encoder when the JSON encoder is assigned (which
+# `Oj.optimize_rails` does), and `Oj::Rails::Encoder` captures `default_options`
+# at construction. Enabling `use_raw_json` afterwards leaves that memoized
+# encoder with `use_raw_json: false`, which double-encodes `JsonValue`.
 unless Oj.default_options[:use_raw_json]
   require 'rails'
-  Oj.optimize_rails
   Oj.default_options = { mode: :rails, use_raw_json: true }
+  Oj.optimize_rails
 end
 
 # NOTE: Add an optimization to make it easier to work with a StringWriter


### PR DESCRIPTION
Fixes #41.

### Problem

On Rails 8.1, `JsonValue` is double-encoded when serialized through `Hash#to_json` / `ActiveSupport::JSON.encode` with no options:

```ruby
{ value: OjSerializers::JsonValue.new('[{"a":1}]') }.to_json
# Rails 8.0: {"value":[{"a":1}]}
# Rails 8.1: {"value":"[{\"a\":1}]"}
```

Rails 8.1 memoizes an option-less encoder when `ActiveSupport::JSON::Encoding.json_encoder=` is assigned, and `Oj::Rails::Encoder` snapshots `Oj.default_options` at construction. `setup.rb` called `Oj.optimize_rails` (which assigns the encoder) *before* enabling `use_raw_json`, so the memoized encoder kept `use_raw_json: false`.

### Fix

Enable `use_raw_json` before calling `Oj.optimize_rails`.

### Tests

Added Rails 8.1 to the CI matrix. The existing "should not double encode JsonValue" spec already covers the option-less `to_json` path and fails on 8.1 without this change. Suite is green on Rails 7.2, 8.0, and 8.1.
